### PR TITLE
성능 개선: 번역 벌크 처리 추가

### DIFF
--- a/scripts/factory/translate-cleanup.test.ts
+++ b/scripts/factory/translate-cleanup.test.ts
@@ -18,6 +18,7 @@ vi.mock('../utils/logger', () => ({
 
 vi.mock('../utils/translate', () => ({
   translate: vi.fn((text: string) => Promise.resolve(`[KO]${text}`)),
+  translateBulk: vi.fn((texts: string[]) => Promise.resolve(texts.map(text => ({ translatedText: `[KO]${text}` })))),
   TranslationRetryExceededError: class TranslationRetryExceededError extends Error {
     constructor() {
       super()

--- a/scripts/factory/translate.test.ts
+++ b/scripts/factory/translate.test.ts
@@ -18,6 +18,20 @@ vi.mock('../utils/logger', () => ({
 }))
 
 vi.mock('../utils/translate', () => {
+  class TranslationRetryExceededError extends Error {
+    constructor() {
+      super()
+      this.name = 'TranslationRetryExceededError'
+    }
+  }
+
+  class TranslationRefusedError extends Error {
+    constructor(public readonly text: string, public readonly reason: string) {
+      super(`번역 거부: ${text} (사유: ${reason})`)
+      this.name = 'TranslationRefusedError'
+    }
+  }
+
   const mockTranslate = vi.fn().mockImplementation(function(text: string, gameType?: any, retryCount?: number, lastError?: any, useTransliteration?: boolean) {
     // 기본적으로 [KO] 접두사 사용, 음역 모드면 [TRANSLITERATION] 접두사 사용
     const prefix = useTransliteration ? '[TRANSLITERATION]' : '[KO]'
@@ -26,18 +40,24 @@ vi.mock('../utils/translate', () => {
   
   return {
     translate: mockTranslate,
-    TranslationRetryExceededError: class TranslationRetryExceededError extends Error {
-      constructor() {
-        super()
-        this.name = 'TranslationRetryExceededError'
+    translateBulk: vi.fn(async (texts: string[], gameType?: any, useTransliteration?: boolean) => {
+      const results: Array<{ translatedText: string; error?: Error }> = []
+      for (const text of texts) {
+        try {
+          const translatedText = await mockTranslate(text, gameType, 0, undefined, useTransliteration)
+          results.push({ translatedText })
+        } catch (error) {
+          if (error instanceof TranslationRetryExceededError || error instanceof TranslationRefusedError) {
+            results.push({ translatedText: text, error })
+            continue
+          }
+          throw error
+        }
       }
-    },
-    TranslationRefusedError: class TranslationRefusedError extends Error {
-      constructor(public readonly text: string, public readonly reason: string) {
-        super(`번역 거부: ${text} (사유: ${reason})`)
-        this.name = 'TranslationRefusedError'
-      }
-    }
+      return results
+    }),
+    TranslationRetryExceededError,
+    TranslationRefusedError
   }
 })
 

--- a/scripts/factory/translate.ts
+++ b/scripts/factory/translate.ts
@@ -5,7 +5,7 @@ import { basename, dirname, join } from 'pathe'
 import { parseToml, parseYaml, stringifyYaml } from '../parser'
 import { hashing } from '../utils/hashing'
 import { log } from '../utils/logger'
-import { translate, TranslationRetryExceededError, TranslationRefusedError } from '../utils/translate'
+import { translateBulk, TranslationRetryExceededError, TranslationRefusedError } from '../utils/translate'
 import { updateAllUpstreams } from '../utils/upstream'
 import { type GameType, shouldUseTransliteration, shouldUseTransliterationForKey } from '../utils/prompts'
 
@@ -336,10 +336,61 @@ async function processLanguageFile (mode: string, sourceDir: string, targetBaseD
     log.verbose(`[${mode}/${file}] 언어 키 발견! "${langKey}" -> "l_korean"`)
   }
 
-  const BATCH_SIZE = 1000 // 1,000 라인마다 파일에 저장
+  const SAVE_BATCH_SIZE = 1000 // 1,000 라인마다 파일에 저장
+  const TRANSLATE_BATCH_SIZE = 20 // 번역 API는 20개 단위 벌크 처리
   let processedCount = 0
   const entries = Object.entries(sourceYaml[`l_${sourceLanguage}`])
   const totalEntries = entries.length
+  const pendingTranslations: Array<{ key: string; sourceValue: string; sourceHash: string; shouldTransliterate: boolean }> = []
+
+  async function flushPendingTranslations (): Promise<void> {
+    if (pendingTranslations.length === 0) {
+      return
+    }
+
+    const translationItems = pendingTranslations.splice(0, pendingTranslations.length)
+    const transliterationItems = translationItems.filter(item => item.shouldTransliterate)
+    const normalItems = translationItems.filter(item => !item.shouldTransliterate)
+
+    const applyResults = (items: typeof translationItems, results: Awaited<ReturnType<typeof translateBulk>>) => {
+      for (const [index, item] of items.entries()) {
+        const result = results[index]
+        let hashForEntry: string | null = item.sourceHash
+        let translatedValue = result.translatedText
+
+        if (result.error instanceof TranslationRetryExceededError) {
+          log.warn(`[${mode}/${file}:${item.key}] 번역 재시도 초과, 원문을 유지합니다.`)
+          translatedValue = item.sourceValue
+          hashForEntry = null
+          untranslatedItems.push({ mod: mode, file, key: item.key, message: item.sourceValue })
+        } else if (result.error instanceof TranslationRefusedError) {
+          log.warn(`[${mode}/${file}:${item.key}] 번역 거부됨: ${result.error.reason}`)
+          log.info(`[${mode}/${file}:${item.key}] 원문을 유지하고 다음 항목으로 계속 진행합니다.`)
+          translatedValue = item.sourceValue
+          hashForEntry = null
+          untranslatedItems.push({
+            mod: mode,
+            file,
+            key: item.key,
+            message: `${item.sourceValue} (번역 거부: ${result.error.reason})`
+          })
+        }
+
+        newYaml.l_korean[item.key] = [translatedValue, hashForEntry]
+        processedCount++
+      }
+    }
+
+    if (normalItems.length > 0) {
+      const normalResults = await translateBulk(normalItems.map(item => item.sourceValue), gameType, false)
+      applyResults(normalItems, normalResults)
+    }
+
+    if (transliterationItems.length > 0) {
+      const transliterationResults = await translateBulk(transliterationItems.map(item => item.sourceValue), gameType, true)
+      applyResults(transliterationItems, transliterationResults)
+    }
+  }
 
   for (const [key, [sourceValue]] of entries) {
     // 타임아웃 확인: 100회마다만 체크
@@ -392,53 +443,22 @@ async function processLanguageFile (mode: string, sourceDir: string, targetBaseD
       log.verbose(`[${mode}/${file}:${key}] 키 레벨 음역 모드 활성화됨 (키가 _adj 또는 _name으로 끝남)`)
     }
 
-    // 번역 요청 (음역 모드 플래그 전달)
-    log.verbose(`[${mode}/${file}:${key}] ${shouldTransliterate ? '음역' : '번역'} 요청: ${sourceHash} | "${sourceValue}"`)
-    let translatedValue: string
-    let hashForEntry: string | null = sourceHash
+    log.verbose(`[${mode}/${file}:${key}] ${shouldTransliterate ? '음역' : '번역'} 요청 대기열 추가: ${sourceHash} | "${sourceValue}"`)
+    pendingTranslations.push({ key, sourceValue, sourceHash, shouldTransliterate })
 
-    try {
-      translatedValue = await translate(sourceValue, gameType, 0, undefined, shouldTransliterate)
-    } catch (error) {
-      if (error instanceof TranslationRetryExceededError) {
-        log.warn(`[${mode}/${file}:${key}] 번역 재시도 초과, 원문을 유지합니다.`)
-        translatedValue = sourceValue
-        hashForEntry = null
-        // 번역되지 않은 항목 추적
-        untranslatedItems.push({
-          mod: mode,
-          file,
-          key,
-          message: sourceValue
-        })
-      } else if (error instanceof TranslationRefusedError) {
-        // 번역 거부 시 원문을 유지하고 계속 진행
-        log.warn(`[${mode}/${file}:${key}] 번역 거부됨: ${error.reason}`)
-        log.info(`[${mode}/${file}:${key}] 원문을 유지하고 다음 항목으로 계속 진행합니다.`)
-        translatedValue = sourceValue
-        hashForEntry = null
-        // 번역되지 않은 항목 추적
-        untranslatedItems.push({
-          mod: mode,
-          file,
-          key,
-          message: `${sourceValue} (번역 거부: ${error.reason})`
-        })
-      } else {
-        throw error
-      }
+    if (pendingTranslations.length >= TRANSLATE_BATCH_SIZE) {
+      await flushPendingTranslations()
     }
 
-    newYaml.l_korean[key] = [translatedValue, hashForEntry]
-    processedCount++
-
     // 1,000 라인마다 중간 저장
-    if (processedCount % BATCH_SIZE === 0) {
+    if (processedCount > 0 && processedCount % SAVE_BATCH_SIZE === 0) {
       const updatedContent = stringifyYaml(newYaml)
       await writeFile(targetPath, updatedContent, 'utf-8')
       log.info(`[${mode}/${file}] 중간 저장 완료 (${processedCount}/${totalEntries} 처리됨)`)
     }
   }
+
+  await flushPendingTranslations()
 
   // 최종 저장
   // 빈 파일 생성 방지: l_korean 객체가 비어있으면 파일을 쓰지 않음

--- a/scripts/utils/ai.ts
+++ b/scripts/utils/ai.ts
@@ -54,6 +54,28 @@ export async function translateAI (text: string, gameType: GameType = 'ck3', ret
 }
 
 /**
+ * 여러 텍스트를 한 번의 AI 요청으로 번역합니다.
+ * 응답 형식은 JSON 배열(또는 translations 필드)을 기대합니다.
+ */
+export async function translateAIBulk (texts: string[], gameType: GameType = 'ck3', useTransliteration: boolean = false): Promise<string[]> {
+  if (texts.length === 0) {
+    return []
+  }
+
+  return new Promise<string[]>((resolve, reject) => {
+    try {
+      return translateAIBulkByModel(resolve, reject, gemini('gemini-3-flash-preview', gameType, useTransliteration), texts)
+    } catch (e) {
+      try {
+        return translateAIBulkByModel(resolve, reject, gemini('gemini-flash-lite-latest', gameType, useTransliteration), texts)
+      } catch (ee) {
+        reject(ee)
+      }
+    }
+  })
+}
+
+/**
  * 번역 거부 사유인지 확인
  */
 function isRefusalReason(finishReason: FinishReason | undefined): boolean {
@@ -122,6 +144,80 @@ Please provide a corrected translation that addresses the issue mentioned above.
         // TranslationRefusedError나 다른 에러를 promise의 reject로 전달
         // reject를 호출하면 외부 Promise가 거부되고, 에러는 호출자에게 전파됨
         // throw하지 않음으로써 큐 작업은 정상 완료되고 unhandled promise rejection 방지
+        reject(error)
+      }
+    },
+  )
+}
+
+function parseBulkResponse (rawText: string, expectedLength: number): string[] {
+  const cleaned = rawText
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/i, '')
+    .trim()
+
+  const parsed = JSON.parse(cleaned)
+  const translations = Array.isArray(parsed) ? parsed : parsed?.translations
+
+  if (!Array.isArray(translations)) {
+    throw new Error('벌크 번역 응답에 translations 배열이 없습니다.')
+  }
+
+  if (translations.length !== expectedLength) {
+    throw new Error(`벌크 번역 응답 길이가 일치하지 않습니다. expected=${expectedLength}, actual=${translations.length}`)
+  }
+
+  return translations.map((item) => String(item))
+}
+
+async function translateAIBulkByModel (
+  resolve: (value: string[] | PromiseLike<string[]>) => void,
+  reject: (reason?: any) => void,
+  model: GenerativeModel,
+  texts: string[],
+): Promise<void> {
+  const queueKey = `bulk:${texts[0]?.slice(0, 30) || 'empty'}:${texts.length}`
+
+  return addQueue(
+    queueKey,
+    async () => {
+      const prompt = [
+        'Translate all items into Korean and return ONLY valid JSON.',
+        'Output format must be exactly: {"translations":["..."]}',
+        'Keep the same order and item count.',
+        'Do not include markdown, explanations, or extra keys.',
+        '',
+        JSON.stringify({ texts }),
+      ].join('\n')
+
+      try {
+        const { response } = await model.generateContent(prompt)
+
+        const promptFeedback = response.promptFeedback
+        if (promptFeedback?.blockReason) {
+          throw new TranslationRefusedError(
+            texts.join(' | ').slice(0, 200),
+            `프롬프트 차단됨: ${promptFeedback.blockReason}${promptFeedback.blockReasonMessage ? ` - ${promptFeedback.blockReasonMessage}` : ''}`
+          )
+        }
+
+        const candidate = response.candidates?.[0]
+        if (candidate && isRefusalReason(candidate.finishReason)) {
+          throw new TranslationRefusedError(
+            texts.join(' | ').slice(0, 200),
+            `응답 거부됨: ${candidate.finishReason}${candidate.finishMessage ? ` - ${candidate.finishMessage}` : ''}`
+          )
+        }
+
+        const translatedItems = parseBulkResponse(response.text(), texts.length)
+          .map(item => item
+            .replaceAll(/\n/g, '\\n')
+            .replaceAll(/[^\\]"/g, '\\"')
+            .replaceAll(/#약(하게|화된|[화한])/g, '#weak')
+            .replaceAll(/#강조/g, '#bold'))
+
+        resolve(translatedItems)
+      } catch (error) {
         reject(error)
       }
     },

--- a/scripts/utils/translate.test.ts
+++ b/scripts/utils/translate.test.ts
@@ -22,6 +22,7 @@ class TranslationRefusedError extends Error {
 // 의존성 모킹
 vi.mock('./ai', () => ({
   translateAI: vi.fn((text: string) => Promise.resolve(`[번역됨]${text}`)),
+  translateAIBulk: vi.fn((texts: string[]) => Promise.resolve(texts.map(text => `[벌크번역]${text}`))),
   TranslationRefusedError,
 }))
 
@@ -486,5 +487,33 @@ describe('TranslationRefusedError 처리', () => {
 
     // translate 함수가 일반 오류도 재throw하는지 확인
     await expect(translate('another text', 'ck3')).rejects.toThrow('네트워크 오류')
+  })
+})
+
+describe('translateBulk', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('벌크 번역 응답을 순서대로 반환해야 함', async () => {
+    const { translateBulk } = await import('./translate')
+    const results = await translateBulk(['first', 'second'], 'ck3', false)
+
+    expect(results).toEqual([
+      { translatedText: '[벌크번역]first' },
+      { translatedText: '[벌크번역]second' },
+    ])
+  })
+
+  it('벌크 번역 실패 시 개별 번역으로 폴백해야 함', async () => {
+    const { translateBulk } = await import('./translate')
+    const { translateAIBulk, translateAI } = await import('./ai')
+
+    vi.mocked(translateAIBulk).mockRejectedValueOnce(new Error('벌크 실패'))
+
+    const results = await translateBulk(['fallback-test'], 'ck3', false)
+
+    expect(results).toEqual([{ translatedText: '[번역됨]fallback-test' }])
+    expect(translateAI).toHaveBeenCalledWith('fallback-test', 'ck3', undefined, false)
   })
 })

--- a/scripts/utils/translate.ts
+++ b/scripts/utils/translate.ts
@@ -1,4 +1,4 @@
-import { translateAI, TranslationRefusedError, type RetranslationContext } from './ai'
+import { translateAI, translateAIBulk, TranslationRefusedError, type RetranslationContext } from './ai'
 import { getCache, hasCache, removeCache, setCache } from './cache'
 import { getDictionary, hasDictionary } from './dictionary'
 import { log } from './logger.js'
@@ -13,6 +13,11 @@ export class TranslationRetryExceededError extends Error {
 }
 
 export { TranslationRefusedError }
+
+export interface BulkTranslateResult {
+  translatedText: string
+  error?: TranslationRefusedError | TranslationRetryExceededError
+}
 
 /**
  * Regex patterns for detecting variable-only text that should be returned immediately without AI translation.
@@ -254,4 +259,109 @@ export async function translate (text: string, gameType: GameType = 'ck3', retry
 
   await setCache(cacheKey, translatedText, gameType)
   return translatedText
+}
+
+/**
+ * 여러 텍스트를 한 번에 처리하여 가능한 경우 AI 벌크 번역을 사용합니다.
+ * 실패 시 개별 번역으로 폴백하여 안정성을 보장합니다.
+ */
+export async function translateBulk (
+  texts: string[],
+  gameType: GameType = 'ck3',
+  useTransliteration: boolean = false,
+): Promise<BulkTranslateResult[]> {
+  if (texts.length === 0) {
+    return []
+  }
+
+  const results: BulkTranslateResult[] = Array.from({ length: texts.length }, () => ({ translatedText: '' }))
+  const unresolved: Array<{ index: number; text: string; cacheKey: string }> = []
+  const transliterationPrefix = useTransliteration ? 'transliteration:' : ''
+
+  for (const [index, text] of texts.entries()) {
+    if (!text || text.trim() === '') {
+      results[index] = { translatedText: '' }
+      continue
+    }
+
+    const normalizedText = text
+
+    if (
+      DOLLAR_VARIABLE_REGEX.test(normalizedText) ||
+      POUND_VARIABLE_REGEX.test(normalizedText) ||
+      AT_VARIABLE_REGEX.test(normalizedText) ||
+      ANGLE_VARIABLE_REGEX.test(normalizedText) ||
+      SQUARE_BRACKET_REGEX.test(normalizedText) ||
+      HASH_FORMAT_REGEX.test(normalizedText) ||
+      SECTION_SIGN_VARIABLE_REGEX.test(normalizedText) ||
+      isVariableOnlyText(normalizedText)
+    ) {
+      results[index] = { translatedText: normalizedText }
+      continue
+    }
+
+    if (hasDictionary(normalizedText, gameType)) {
+      results[index] = { translatedText: sanitizeTranslationText(getDictionary(normalizedText, gameType)!) }
+      continue
+    }
+
+    const cacheKey = `${transliterationPrefix}${normalizedText}`
+    if (await hasCache(cacheKey, gameType)) {
+      const cached = await getCache(cacheKey, gameType)
+      if (cached) {
+        const sanitizedCached = sanitizeTranslationText(cached)
+        if (sanitizedCached !== cached) {
+          await setCache(cacheKey, sanitizedCached, gameType)
+        }
+
+        const { isValid } = validateTranslation(normalizedText, sanitizedCached, gameType)
+        if (isValid) {
+          results[index] = { translatedText: sanitizedCached }
+          continue
+        }
+
+        await removeCache(cacheKey, gameType)
+      }
+    }
+
+    unresolved.push({ index, text: normalizedText, cacheKey })
+  }
+
+  if (unresolved.length === 0) {
+    return results
+  }
+
+  try {
+    const aiTranslated = await translateAIBulk(unresolved.map(item => item.text), gameType, useTransliteration)
+
+    for (const [bulkIndex, unresolvedItem] of unresolved.entries()) {
+      const translatedText = sanitizeTranslationText(aiTranslated[bulkIndex] || unresolvedItem.text)
+      const validation = validateTranslation(unresolvedItem.text, translatedText, gameType)
+
+      if (validation.isValid) {
+        await setCache(unresolvedItem.cacheKey, translatedText, gameType)
+        results[unresolvedItem.index] = { translatedText }
+      } else {
+        // 검증 실패 시 개별 번역으로 재시도
+        const fallback = await translate(unresolvedItem.text, gameType, 0, undefined, useTransliteration)
+        results[unresolvedItem.index] = { translatedText: fallback }
+      }
+    }
+  } catch {
+    // 벌크 요청 실패 시 개별 번역으로 폴백
+    for (const unresolvedItem of unresolved) {
+      try {
+        const translatedText = await translate(unresolvedItem.text, gameType, 0, undefined, useTransliteration)
+        results[unresolvedItem.index] = { translatedText }
+      } catch (error) {
+        if (error instanceof TranslationRefusedError || error instanceof TranslationRetryExceededError) {
+          results[unresolvedItem.index] = { translatedText: unresolvedItem.text, error }
+        } else {
+          throw error
+        }
+      }
+    }
+  }
+
+  return results
 }


### PR DESCRIPTION
### Motivation
- 개별 텍스트를 한 건씩 AI에 요청하는 현재 흐름은 대량 파일 처리 시 느려서 번역 처리 성능 향상이 필요했습니다.
- 동일한 모달리티(일반 번역 / 음역)를 묶어 한 번에 요청하면 API 호출 횟수와 레이턴시를 줄일 수 있습니다.
- 실패 시 안정성 확보를 위해 벌크 실패에 대한 개별 폴백과 기존의 거부/재시도 로직을 유지해야 했습니다.

### Description
- `scripts/factory/translate.ts`에서 항목을 즉시 요청하지 않고 내부 대기열에 모아 `TRANSLATE_BATCH_SIZE=20` 단위로 `flushPendingTranslations()`를 호출하도록 변경했습니다.
- `scripts/utils/translate.ts`에 `translateBulk()`를 추가해 변수·사전·캐시 선처리 → `translateAIBulk()` 호출 → 검증 실패 시 개별 `translate()` 폴백 흐름을 구현했습니다.
- `scripts/utils/ai.ts`에 `translateAIBulk()`와 `parseBulkResponse()`를 추가해 Gemini로부터 JSON 배열(또는 `translations` 필드)을 받아 순서·개수 검증 및 정규화를 수행하도록 했습니다.
- 관련 테스트(`scripts/utils/translate.test.ts`, `scripts/factory/translate.test.ts`, `scripts/factory/translate-cleanup.test.ts`)를 벌크 경로에 맞게 보강 및 목(mock) 갱신했습니다.

### Testing
- 전체 테스트: `pnpm test`를 실행했고 모든 테스트가 통과했습니다 (436 tests passed).
- 변경된 유닛 테스트: `scripts/utils/translate.test.ts`, `scripts/factory/translate.test.ts`, `scripts/factory/translate-cleanup.test.ts`의 추가/수정된 케이스가 성공적으로 통과했습니다.
- 정적 타입 검사: `pnpm exec tsc --noEmit`는 저장소 내 기존 타입 설정 및 기존 파일의 TS 이슈로 실패했으며 이 문제는 이번 변경과 무관한 기존 문제로 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c74f0ef4608331a1aa2da7af5ed6c6)