### PR TITLE
fix: semantic 전략에서 원본 태그명 보존 및 확장 태그 처리

### DIFF
--- a/scripts/utils/upstream.test.ts
+++ b/scripts/utils/upstream.test.ts
@@ -148,4 +148,56 @@ language = "english"
       expect(allConfigs.length).toBe(2)
     })
   })
+
+  describe('getLatestRefFromRemote', () => {
+    it('semantic 전략에서 1.18.1.b 같은 확장 태그를 최신 버전으로 선택해야 함', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ([
+          { tag_name: '1.18.1.b' },
+          { tag_name: '1.18.1.a' },
+          { tag_name: '1.18.1' },
+          { tag_name: '1.8.3' }
+        ])
+      })
+
+      const { getLatestRefFromRemote } = await import('./upstream')
+      const latestRef = await getLatestRefFromRemote(
+        'https://github.com/cybrxkhan/RICE-for-CK3.git',
+        'ck3/RICE/upstream',
+        'semantic'
+      )
+
+      expect(latestRef).toEqual({
+        type: 'tag',
+        name: '1.18.1.b'
+      })
+    })
+
+    it('semantic 전략에서 v 접두사가 있는 태그도 원본 이름으로 반환해야 함', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ([
+          { tag_name: 'v1.9.1' },
+          { tag_name: 'v1.10.0' }
+        ])
+      })
+
+      const { getLatestRefFromRemote } = await import('./upstream')
+      const latestRef = await getLatestRefFromRemote(
+        'https://github.com/test/test.git',
+        'ck3/Test/upstream',
+        'semantic'
+      )
+
+      expect(latestRef).toEqual({
+        type: 'tag',
+        name: 'v1.10.0'
+      })
+    })
+  })
 })

--- a/scripts/utils/upstream.ts
+++ b/scripts/utils/upstream.ts
@@ -354,19 +354,40 @@ async function getSemanticVersion(repoUrl: string, configPath: string): Promise<
       }
       
       const releases = await response.json() as Array<{ tag_name: string }>
-      
-      // semver 유효한 태그만 필터링
-      const validSemvers = releases
-        .map(r => r.tag_name.replace(/^v/, ''))
-        .filter(tag => semver.valid(tag))
-      
-      if (validSemvers.length === 0) {
+
+      // semver 정렬을 위해 태그를 파싱하되, 실제 체크아웃에는 원본 태그명을 사용
+      const parsedReleases = releases
+        .map(({ tag_name }) => {
+          const normalizedTag = tag_name.replace(/^v/, '')
+          const parsed = semver.parse(normalizedTag) ?? semver.coerce(normalizedTag)
+          if (!parsed) {
+            return null
+          }
+
+          return {
+            originalTag: tag_name,
+            normalizedTag,
+            normalizedVersion: parsed.version
+          }
+        })
+        .filter((release): release is { originalTag: string, normalizedTag: string, normalizedVersion: string } => release !== null)
+
+      if (parsedReleases.length === 0) {
         throw new Error(`유효한 시멘틱 버전 태그를 찾을 수 없음`)
       }
-      
-      // semver 정렬
-      const sorted = validSemvers.sort(semver.compare)
-      return { type: 'tag', name: `v${sorted[sorted.length - 1]}` }
+
+      // semver 정렬 (오름차순) 후 가장 마지막 값 선택
+      const naturalSorter = natsort({ desc: true })
+      const sorted = parsedReleases.sort((a, b) => {
+        const versionCompare = semver.compare(a.normalizedVersion, b.normalizedVersion)
+        if (versionCompare !== 0) {
+          return versionCompare
+        }
+
+        // 같은 시멘틱 버전(예: 1.18.1, 1.18.1.a, 1.18.1.b)에서는 자연 정렬로 최신 태그 선택
+        return -naturalSorter(a.normalizedTag, b.normalizedTag)
+      })
+      return { type: 'tag', name: sorted[sorted.length - 1].originalTag }
     },
     `${configPath}-semantic`
   )


### PR DESCRIPTION
### Motivation

- GitHub Release 태그를 semver로 정렬한 뒤 체크아웃할 때 태그명에 `v`를 강제로 붙여 `git clone --branch "v..."`를 시도하여 실제 태그와 불일치로 클론 실패가 발생했습니다.  
- 또한 `1.18.1.b` 같은 strict semver가 아닌 확장 태그는 기존 필터링에서 누락되거나 올바르게 최신 판별되지 않았습니다.

### Description

- `scripts/utils/upstream.ts`의 시멘틱 버전 선택 로직을 개선해 Releases 목록에서 받은 `tag_name`을 그대로 보존하도록 변경했습니다.  
- 태그 정렬은 semver 기준으로 수행하되 `semver.parse` 실패 시 `semver.coerce`를 사용해 숫자 버전을 확보하고, 체크아웃에는 원본 `tag_name`을 사용하도록 했습니다.  
- 동일 숫자 버전 집합(예: `1.18.1`, `1.18.1.a`, `1.18.1.b`)은 자연 정렬(natsort)을 적용해 접미사 기준으로 최신 태그를 선택하도록 보완했습니다.  
- 이 변경에 대응해 `scripts/utils/upstream.test.ts`에 회귀 테스트를 추가/보강해(`1.18.1.b` 선택, `v` 접두사 보존 등) 동작을 검증했습니다.

### Testing

- `pnpm test`를 실행해 모든 자동화 테스트가 성공적으로 통과했음을 확인했습니다 (`436` tests 모두 통과).  
- `pnpm exec tsc --noEmit`(타입 검사)은 저장소의 기존 선행 타입 오류로 실패했으며 이번 변경과는 무관합니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7525e9a3c83319341e04c2905c02f)