### PR TITLE
fix: 모드별 번역 오류 발생 시 다음 모드 번역 계속 처리

### DIFF
--- a/scripts/factory/translate.test.ts
+++ b/scripts/factory/translate.test.ts
@@ -772,6 +772,67 @@ transliteration_files = ["custom_events_l_english.yml", "*_special_*"]
     await rm(testDir, { recursive: true, force: true })
   })
 
+  it('한 모드에서 오류가 발생해도 다음 모드 번역을 계속 진행해야 함', async () => {
+    const { processModTranslations } = await import('./translate')
+    const { translateBulk } = await import('../utils/translate')
+    const prompts = await import('../utils/prompts')
+
+    const modDir = join(testDir, 'mode-fallback-mod')
+    const upstreamDir = join(modDir, 'upstream')
+
+    const metaContent = `
+[upstream]
+localization = ["."]
+language = "english"
+`
+
+    const sourceContent = `l_english:
+  normal_key: "Normal text"
+  dynasty_name: "Dynasty Name"
+`
+
+    await mkdir(upstreamDir, { recursive: true })
+    await writeFile(join(modDir, 'meta.toml'), metaContent, 'utf-8')
+    await writeFile(join(upstreamDir, 'events_l_english.yml'), sourceContent, 'utf-8')
+
+    vi.spyOn(prompts, 'shouldUseTransliterationForKey').mockImplementation((key: string) => key === 'dynasty_name')
+
+    const originalTranslateBulk = vi.mocked(translateBulk).getMockImplementation()
+    vi.mocked(translateBulk).mockImplementation(async (texts: string[], gameType?: any, useTransliteration?: boolean) => {
+      if (!useTransliteration) {
+        throw new Error('일반 번역 모드 실패')
+      }
+      if (originalTranslateBulk) {
+        return originalTranslateBulk(texts, gameType, useTransliteration)
+      }
+      return texts.map(text => ({ translatedText: `[TRANSLITERATION]${text}` }))
+    })
+
+    const result = await processModTranslations({
+      rootDir: testDir,
+      mods: ['mode-fallback-mod'],
+      gameType: 'ck3',
+      onlyHash: false
+    })
+
+    const outputPath = join(modDir, 'mod', 'localization', 'korean', '___events_l_korean.yml')
+    const outputContent = await readFile(outputPath, 'utf-8')
+    const outputYaml = parseYaml(outputContent)
+
+    // 일반 번역 모드 오류가 난 항목은 원문 유지
+    expect(outputYaml.l_korean['normal_key'][0]).toBe('Normal text')
+    expect(outputYaml.l_korean['normal_key'][1]).toBeNull()
+
+    // 다음 모드(음역)는 계속 진행되어 번역 결과가 반영되어야 함
+    expect(outputYaml.l_korean['dynasty_name'][0]).not.toBe('Dynasty Name')
+    expect(outputYaml.l_korean['dynasty_name'][1]).toBeDefined()
+
+    expect(result.untranslatedItems.some(item => item.key === 'normal_key')).toBe(true)
+    expect(result.untranslatedItems.some(item => item.key === 'dynasty_name')).toBe(false)
+
+    await rm(testDir, { recursive: true, force: true })
+  })
+
   it('중복되는 항목을 제거하고 고유한 항목만 JSON 파일에 저장해야 함', async () => {
     // 같은 모드 내에서 여러 localization 경로에 동일한 파일이 있는 경우를 시뮬레이션
     // 이런 경우 같은 mod::file::key 조합이 중복될 수 있음

--- a/scripts/factory/translate.ts
+++ b/scripts/factory/translate.ts
@@ -381,15 +381,34 @@ async function processLanguageFile (mode: string, sourceDir: string, targetBaseD
       }
     }
 
-    if (normalItems.length > 0) {
-      const normalResults = await translateBulk(normalItems.map(item => item.sourceValue), gameType, false)
-      applyResults(normalItems, normalResults)
+    async function processModeItems (items: typeof translationItems, useTransliteration: boolean): Promise<void> {
+      if (items.length === 0) {
+        return
+      }
+
+      try {
+        const results = await translateBulk(items.map(item => item.sourceValue), gameType, useTransliteration)
+        applyResults(items, results)
+      } catch (error) {
+        const modeLabel = useTransliteration ? '음역 모드' : '번역 모드'
+        log.warn(`[${mode}/${file}] ${modeLabel} 처리 중 오류 발생, 해당 모드는 원문 유지 후 다음 모드로 진행합니다.`)
+        log.warn(`[${mode}/${file}] ${modeLabel} 오류 상세: ${String(error)}`)
+
+        for (const item of items) {
+          newYaml.l_korean[item.key] = [item.sourceValue, null]
+          untranslatedItems.push({
+            mod: mode,
+            file,
+            key: item.key,
+            message: `${item.sourceValue} (${modeLabel} 오류: ${String(error)})`
+          })
+          processedCount++
+        }
+      }
     }
 
-    if (transliterationItems.length > 0) {
-      const transliterationResults = await translateBulk(transliterationItems.map(item => item.sourceValue), gameType, true)
-      applyResults(transliterationItems, transliterationResults)
-    }
+    await processModeItems(normalItems, false)
+    await processModeItems(transliterationItems, true)
   }
 
   for (const [key, [sourceValue]] of entries) {


### PR DESCRIPTION
### Motivation
- 번역 실행 중 한 모드(번역 또는 음역)에서 예외가 발생하면 이후 모드 처리가 중단되어 전체 번역이 영향을 받는 문제를 해결하기 위함.

### Description
- `scripts/factory/translate.ts`의 `flushPendingTranslations`에 모드별 처리 함수 `processModeItems`를 추가하여 각 모드를 독립적으로 처리하도록 변경했습니다.
- 한 모드에서 예외가 발생하면 해당 모드의 항목은 원문(`hash: null`)으로 기록하고 `untranslatedItems`에 오류 원인을 포함해 저장한 뒤 다음 모드를 계속 실행하도록 예외 처리를 추가했습니다.
- 관련 로그를 보강하여 모드 오류 발생 시 모드명(예: `음역 모드` / `번역 모드`)과 오류 상세를 남기도록 했습니다.
- 회귀 방지를 위해 `scripts/factory/translate.test.ts`에 `한 모드에서 오류가 발생해도 다음 모드 번역을 계속 진행해야 함` 테스트를 추가했습니다.
- 변경 파일: `scripts/factory/translate.ts`, `scripts/factory/translate.test.ts`.

### Testing
- 타입 검사: `pnpm exec tsc --noEmit` 를 실행하여 타입 검사 통과를 확인했습니다 (성공).
- 단위 테스트: `pnpm test` 를 실행했고 전체 테스트가 통과했습니다 (`439` 테스트 통과, 실패 없음).
- 린트: 프로젝트 `package.json`에 `lint` 스크립트가 없어 `pnpm lint`는 실행되지 않았음을 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c75468eb908331ab21d3b290c0f601)