### PR TITLE
ci: self-hosted 제거 및 주간 문서 이슈 생성 조건 개선

### DIFF
--- a/.github/workflows/invalidate-on-dictionary-update.yml
+++ b/.github/workflows/invalidate-on-dictionary-update.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   invalidate-dictionary:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     env:

--- a/.github/workflows/invalidate-on-transliteration-files-change.yml
+++ b/.github/workflows/invalidate-on-transliteration-files-change.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   invalidate-transliteration-files:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     env:

--- a/.github/workflows/retranslate-invalid-translations.yml
+++ b/.github/workflows/retranslate-invalid-translations.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   retranslate-invalid:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     env:

--- a/.github/workflows/translate-ck3.yml
+++ b/.github/workflows/translate-ck3.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   translate:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/translate-stellaris.yml
+++ b/.github/workflows/translate-stellaris.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   translate:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/translate-vic3.yml
+++ b/.github/workflows/translate-vic3.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   translate:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/weekly-docs-update.yml
+++ b/.github/workflows/weekly-docs-update.yml
@@ -23,12 +23,19 @@ jobs:
         id: changes
         run: |
           # [skip ci] 커밋 제외하고 지난 7일간 변경사항 수집
-          CHANGES=$(git log --since="7 days ago" --oneline --no-merges | grep -v "\[skip ci\]" || echo "변경사항 없음")
+          CHANGES=$(git log --since="7 days ago" --oneline --no-merges | grep -v "\[skip ci\]" || true)
+          if [ -z "$CHANGES" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            CHANGES="변경사항 없음"
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
           echo "changes<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create documentation update issue
+        if: steps.changes.outputs.has_changes == 'true'
         uses: actions/github-script@v8
         env:
           CHANGES: ${{ steps.changes.outputs.changes }}


### PR DESCRIPTION
### Motivation

- self-hosted 러너 의존성을 제거하고 GitHub 호스티드 리눅스 러너로 통일해 리소스 관리 및 안정성을 개선하려는 목적입니다.
- 주간 문서 현행화 워크플로우에서 변경사항이 없을 때 불필요한 이슈가 생성되는 것을 방지하여 잡음을 줄이기 위한 목적입니다.

### Description

- 번역 및 무효화 관련 워크플로우의 `runs-on: self-hosted`를 모두 `runs-on: ubuntu-latest`로 변경했습니다 (`translate-ck3.yml`, `translate-vic3.yml`, `translate-stellaris.yml`, `invalidate-on-dictionary-update.yml`, `invalidate-on-transliteration-files-change.yml`, `retranslate-invalid-translations.yml`).
- `.github/workflows/weekly-docs-update.yml`의 변경사항 수집 단계에서 `has_changes` 출력을 추가하고 `git log` 실패 시 빈 출력으로 처리하도록 변경했습니다 (`CHANGES=$(git log ... || true)`), 변경사항이 없으면 `has_changes=false`를 설정하도록 했습니다.
- 주간 문서 이슈 생성 스텝에 `if: steps.changes.outputs.has_changes == 'true'` 조건을 추가해 변경사항이 없을 경우 이슈를 생성하지 않도록 했습니다.

### Testing

- 자동화된 테스트로 `pnpm test`를 실행했고 모든 테스트가 통과했습니다 (`21`개 테스트 파일, `438`개 단위 테스트 성공).
- 타입 검사로 `pnpm exec tsc --noEmit`를 실행했고 오류 없이 성공했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7554ce57c8331a9d12c001d85749b)