### PR TITLE
feat: 모드 단위 번역 병렬 처리 지원

### DIFF
--- a/scripts/factory/translate.test.ts
+++ b/scripts/factory/translate.test.ts
@@ -74,6 +74,7 @@ describe('processLanguageFile 증분 쓰기', () => {
     testDir = join(tmpdir(), `translate-test-${Date.now()}`)
     await mkdir(testDir, { recursive: true })
     delete process.env.TRANSLATE_BATCH_SIZE
+    delete process.env.TRANSLATE_MOD_CONCURRENCY
   })
 
   afterEach(async () => {
@@ -787,6 +788,58 @@ language = "english"
 
     // 정리
     await rm(testDir, { recursive: true, force: true })
+  })
+
+  it('모드 단위 병렬 처리 동시성을 적용해야 함', async () => {
+    const testDir = join(tmpdir(), `translate-test-mod-concurrency-${Date.now()}`)
+    const ck3Dir = join(testDir, 'ck3')
+
+    const mod1Dir = join(ck3Dir, 'mod1')
+    const mod2Dir = join(ck3Dir, 'mod2')
+    await mkdir(join(mod1Dir, 'upstream'), { recursive: true })
+    await mkdir(join(mod2Dir, 'upstream'), { recursive: true })
+
+    await writeFile(join(mod1Dir, 'meta.toml'), `
+[upstream]
+localization = ["."]
+language = "english"
+`, 'utf-8')
+    await writeFile(join(mod2Dir, 'meta.toml'), `
+[upstream]
+localization = ["."]
+language = "english"
+`, 'utf-8')
+    await writeFile(join(mod1Dir, 'upstream', 'mod1_l_english.yml'), `l_english:\n key1:0 "Value 1"\n`, 'utf-8')
+    await writeFile(join(mod2Dir, 'upstream', 'mod2_l_english.yml'), `l_english:\n key2:0 "Value 2"\n`, 'utf-8')
+
+    const { translate } = await import('../utils/translate')
+    vi.mocked(translate).mockImplementation(async (text: string) => {
+      await new Promise(resolve => setTimeout(resolve, 120))
+      return `[KO]${text}`
+    })
+
+    process.env.TRANSLATE_MOD_CONCURRENCY = '1'
+    const { processModTranslations } = await import('./translate')
+    const sequentialStart = Date.now()
+    await processModTranslations({
+      rootDir: ck3Dir,
+      mods: ['mod1', 'mod2'],
+      gameType: 'ck3',
+      onlyHash: false
+    })
+    const sequentialElapsed = Date.now() - sequentialStart
+
+    process.env.TRANSLATE_MOD_CONCURRENCY = '2'
+    const parallelStart = Date.now()
+    await processModTranslations({
+      rootDir: ck3Dir,
+      mods: ['mod1', 'mod2'],
+      gameType: 'ck3',
+      onlyHash: false
+    })
+    const parallelElapsed = Date.now() - parallelStart
+
+    expect(parallelElapsed).toBeLessThan(sequentialElapsed)
   })
 
   it('한 모드에 여러 파일이 있을 때 번역 거부가 발생해도 다른 파일들은 정상 처리되어야 함', async () => {

--- a/scripts/factory/translate.ts
+++ b/scripts/factory/translate.ts
@@ -14,6 +14,7 @@ const execAsync = promisify(exec)
 // 번역 거부 항목 출력 파일 이름 접미사
 const UNTRANSLATED_ITEMS_FILE_SUFFIX = 'untranslated-items.json'
 const DEFAULT_TRANSLATE_BATCH_SIZE = 20
+const DEFAULT_MOD_CONCURRENCY = 4
 
 /**
  * Shell 명령어에 안전하게 사용할 수 있도록 파일 경로를 이스케이프합니다.
@@ -56,6 +57,25 @@ function getTranslateBatchSize (): number {
   return parsed
 }
 
+/**
+ * 모드 단위 병렬 처리 동시성 값을 환경변수에서 읽어옵니다.
+ * 잘못된 값이 들어오면 기본값을 사용합니다.
+ */
+function getModConcurrency (): number {
+  const concurrencyEnv = process.env.TRANSLATE_MOD_CONCURRENCY
+  if (!concurrencyEnv) {
+    return DEFAULT_MOD_CONCURRENCY
+  }
+
+  const parsed = Number.parseInt(concurrencyEnv, 10)
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    log.warn(`TRANSLATE_MOD_CONCURRENCY 값이 올바르지 않아 기본값(${DEFAULT_MOD_CONCURRENCY})을 사용합니다: ${concurrencyEnv}`)
+    return DEFAULT_MOD_CONCURRENCY
+  }
+
+  return parsed
+}
+
 interface ModTranslationsOptions {
   rootDir: string
   mods: string[]
@@ -83,6 +103,12 @@ export interface TranslationResult {
   untranslatedItems: UntranslatedItem[]
 }
 
+interface ModProcessResult {
+  mod: string
+  untranslatedItems: UntranslatedItem[]
+  timeoutReached: boolean
+}
+
 export async function processModTranslations ({ rootDir, mods, gameType, onlyHash = false, timeoutMinutes }: ModTranslationsOptions): Promise<TranslationResult> {
   // 번역 작업 전에 해당 게임의 upstream 리포지토리만 업데이트
   log.start(`${gameType.toUpperCase()} Upstream 리포지토리 업데이트 중...`)
@@ -100,9 +126,10 @@ export async function processModTranslations ({ rootDir, mods, gameType, onlyHas
     log.info(`타임아웃 설정: ${timeoutMinutes ?? 15}분`)
   }
 
-  const allUntranslatedItems: UntranslatedItem[] = []
+  const modConcurrency = Math.min(getModConcurrency(), Math.max(mods.length, 1))
+  log.info(`모드 병렬 처리 동시성: ${modConcurrency}`)
 
-  for (const mod of mods) {
+  const modTasks = mods.map((mod) => async (): Promise<ModProcessResult> => {
     const processes: Promise<UntranslatedItem[]>[] = []
     const locPathCleanupTasks: Array<{ targetDir: string; expectedKoreanFiles: string[]; mod: string; locPath: string }> = []
     log.start(`[${mod}] 작업 시작 (원본 파일 경로: ${rootDir}/${mod})`)
@@ -111,7 +138,7 @@ export async function processModTranslations ({ rootDir, mods, gameType, onlyHas
 
     // `meta.toml`이 존재하지 않거나 디렉토리 등 파일이 아니면 무시
     if (!(await stat(metaPath)).isFile()) {
-      continue
+      return { mod, untranslatedItems: [], timeoutReached: false }
     }
 
     const metaContent = await readFile(metaPath, 'utf-8')
@@ -140,7 +167,7 @@ export async function processModTranslations ({ rootDir, mods, gameType, onlyHas
               `upstream 클론이 누락되었을 수 있습니다.\n` +
               `필요 시 다음 명령어를 실행해 주세요: pnpm upstream ${gameType} \"${mod}\"`
             )
-            continue
+            return { mod, untranslatedItems: [], timeoutReached: false }
           }
 
           throw new Error(
@@ -206,18 +233,15 @@ export async function processModTranslations ({ rootDir, mods, gameType, onlyHas
         if (error instanceof TimeoutReachedError) {
           log.warn(`[${mod}] 타임아웃으로 인해 번역 중단됨`)
           log.info(`타임아웃 도달: 처리된 작업까지 저장하고 종료합니다`)
-          // 타임아웃 시에도 현재까지 수집된 항목 반환
-          allUntranslatedItems.push(...untranslatedItems)
-          return saveAndReturnResult(projectRoot, gameType, allUntranslatedItems)
+          // 타임아웃 시에도 현재까지 수집된 항목은 반환하여 상위에서 저장합니다.
+          return { mod, untranslatedItems, timeoutReached: true }
         } else {
           // 다른 예외는 그대로 throw
           throw error
         }
       }
     }
-    
-    allUntranslatedItems.push(...untranslatedItems)
-    
+
     log.success(`[${mod}] 번역 완료`)
     
     // 번역되지 않은 항목 요약 출력
@@ -227,6 +251,31 @@ export async function processModTranslations ({ rootDir, mods, gameType, onlyHas
       }
     } else if (!onlyHash) {
       log.success(`모든 항목이 성공적으로 번역되었습니다.`)
+    }
+    return { mod, untranslatedItems, timeoutReached: false }
+  })
+
+  const allUntranslatedItems: UntranslatedItem[] = []
+  let hasTimeout = false
+
+  for (let i = 0; i < modTasks.length; i += modConcurrency) {
+    const chunk = modTasks.slice(i, i + modConcurrency)
+    const executing = chunk.map(task => task())
+    const results = await Promise.allSettled(executing)
+
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        allUntranslatedItems.push(...result.value.untranslatedItems)
+        if (result.value.timeoutReached) {
+          hasTimeout = true
+        }
+      } else {
+        throw result.reason
+      }
+    }
+
+    if (hasTimeout) {
+      break
     }
   }
 


### PR DESCRIPTION
### Motivation
- 여러 모드를 병렬로 처리하여 전체 번역 시간을 단축하고 CI/실행 환경에서 병렬 처리 제어를 가능하게 하기 위해 변경했습니다.
- 환경별 리소스에 맞춰 병렬 동시성을 쉽게 조정할 수 있도록 환경변수 기반 설정을 추가했습니다.
- 모드 처리 중 타임아웃이나 일부 실패가 발생해도 안전하게 현재까지의 결과를 수집해 저장하도록 견고성을 개선했습니다.

### Description
- `processModTranslations`를 모드 단위 병렬 처리 방식으로 변경하여 모드 목록을 작업 큐(`modTasks`)로 만들어 청크 단위(`modConcurrency`)로 병렬 실행하도록 구현했습니다.
- 모드 동시성 제어용 환경변수 `TRANSLATE_MOD_CONCURRENCY`와 파서 `getModConcurrency()`를 추가하고 기본값을 `4`로 설정했습니다.
- 모드 처리 결과 구조체 `ModProcessResult`를 도입해 각 모드의 번역 미완료 항목과 `timeoutReached` 플래그를 상위에서 집계하도록 개선했습니다.
- 타임아웃 발생 시 해당 시점까지 처리된 모드 결과를 모아서 `saveAndReturnResult()`로 저장하도록 흐름을 변경했습니다.
- 관련 단위 테스트를 보강하여 환경변수 초기화(`TRANSLATE_MOD_CONCURRENCY`)를 추가하고 병렬 동작을 검증하는 테스트를 새로 추가했습니다 (`scripts/factory/translate.test.ts`).

### Testing
- `pnpm test scripts/factory/translate.test.ts`를 실행하여 해당 테스트 파일의 모든 테스트가 통과함을 확인했습니다 (20 tests, 통과).
- 전체 테스트 스위트(`pnpm test`)를 실행하여 모든 테스트가 통과했음을 확인했습니다 (전체 테스트 통과).
- 타입 체크(`pnpm exec tsc --noEmit`)를 실행하여 타입 에러가 없음을 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c762e129048331bfb45ae2f1d9576f)