### PR TITLE
fix: 주간 Codex 리팩토링 워크플로우 CODEX_HOME 컨텍스트 오류 수정

### DIFF
--- a/.github/workflows/weekly-codex-refactor.yml
+++ b/.github/workflows/weekly-codex-refactor.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LOG_LEVEL: "${{ vars.LOG_LEVEL }}"
-      CODEX_HOME: "${{ runner.temp }}/codex-home"
+      CODEX_HOME: "${{ github.workspace }}/.codex-home"
     steps:
       - name: 저장소 체크아웃
         uses: actions/checkout@v6


### PR DESCRIPTION
### Motivation
- 워크플로우 파싱 단계에서 `Unrecognized named-value: 'runner'` 오류를 발생시키던 잡 레벨 `env`의 `CODEX_HOME` 참조를 안전한 컨텍스트로 변경하여 GitHub Actions가 정상 실행되도록 하기 위함입니다.

### Description
- `.github/workflows/weekly-codex-refactor.yml`의 `CODEX_HOME` 값을 `${{ runner.temp }}/codex-home`에서 `${{ github.workspace }}/.codex-home`로 변경했습니다.

### Testing
- `pnpm exec tsc --noEmit`를 실행하여 타입 검사에 성공했습니다.
- `pnpm test`를 실행하여 전체 테스트(451개)가 모두 성공했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7666882208331aa0b821d8135c996)