### PR TITLE
벌크 번역 실패 로그에 AI 응답 미리보기 및 모드명 추가

### DIFF
--- a/scripts/factory/translate.ts
+++ b/scripts/factory/translate.ts
@@ -505,7 +505,7 @@ async function processLanguageFile (mode: string, sourceDir: string, targetBaseD
       }
 
       try {
-        const results = await translateBulk(items.map(item => item.sourceValue), gameType, useTransliteration)
+        const results = await translateBulk(items.map(item => item.sourceValue), gameType, useTransliteration, { modName: mode })
         applyResults(items, results)
       } catch (error) {
         const modeLabel = useTransliteration ? '음역 모드' : '번역 모드'

--- a/scripts/utils/ai.test.ts
+++ b/scripts/utils/ai.test.ts
@@ -69,6 +69,8 @@ describe('AI 유틸리티', () => {
         if (jsonParseErrorMessage) {
           expect(message).toContain(jsonParseErrorMessage)
         }
+        expect(message).toContain('AI 응답 원문:')
+        expect(message).toContain(raw)
       }
     })
 

--- a/scripts/utils/ai.ts
+++ b/scripts/utils/ai.ts
@@ -256,7 +256,12 @@ export function parseBulkResponse (rawText: string, expectedLength: number): str
 
   if (parsed === undefined) {
     const errorMessage = lastError instanceof Error ? lastError.message : String(lastError)
-    throw new Error(`벌크 번역 JSON 파싱에 실패했습니다: ${errorMessage}`)
+    const compactRawText = rawText.replace(/\s+/g, ' ').trim()
+    const previewLimit = 500
+    const rawTextPreview = compactRawText.length > previewLimit
+      ? `${compactRawText.slice(0, previewLimit)}...`
+      : compactRawText
+    throw new Error(`벌크 번역 JSON 파싱에 실패했습니다: ${errorMessage} | AI 응답 원문: ${rawTextPreview}`)
   }
 
   const translations = Array.isArray(parsed) ? parsed : (parsed as { translations?: unknown[] })?.translations

--- a/scripts/utils/translate.test.ts
+++ b/scripts/utils/translate.test.ts
@@ -539,13 +539,18 @@ describe('translateBulk', () => {
   it('벌크 번역 실패 시 개별 번역으로 폴백해야 함', async () => {
     const { translateBulk } = await import('./translate')
     const { translateAIBulk, translateAI } = await import('./ai')
+    const { log } = await import('./logger')
 
     vi.mocked(translateAIBulk).mockRejectedValueOnce(new Error('벌크 실패'))
 
-    const results = await translateBulk(['fallback-test'], 'ck3', false)
+    const results = await translateBulk(['fallback-test'], 'ck3', false, { modName: 'RICE' })
 
     expect(results).toEqual([{ translatedText: '[번역됨]fallback-test' }])
     expect(translateAI).toHaveBeenCalledWith('fallback-test', 'ck3', undefined, false)
+    const warnMessages = vi.mocked(log.warn).mock.calls
+      .map(call => call[0])
+      .filter((value): value is string => typeof value === 'string')
+    expect(warnMessages.some(message => message.includes('[모드:RICE] [벌크] AI 벌크 요청 실패, 개별 번역으로 폴백'))).toBe(true)
   })
 
   it('벌크 처리에서 캐시 응답 로그를 남겨야 함', async () => {

--- a/scripts/utils/translate.ts
+++ b/scripts/utils/translate.ts
@@ -19,6 +19,10 @@ export interface BulkTranslateResult {
   error?: TranslationRefusedError | TranslationRetryExceededError
 }
 
+interface BulkTranslateContext {
+  modName?: string
+}
+
 /**
  * Regex patterns for detecting variable-only text that should be returned immediately without AI translation.
  * 
@@ -269,6 +273,7 @@ export async function translateBulk (
   texts: string[],
   gameType: GameType = 'ck3',
   useTransliteration: boolean = false,
+  context?: BulkTranslateContext,
 ): Promise<BulkTranslateResult[]> {
   if (texts.length === 0) {
     return []
@@ -277,6 +282,7 @@ export async function translateBulk (
   const results: BulkTranslateResult[] = Array.from({ length: texts.length }, () => ({ translatedText: '' }))
   const unresolved: Array<{ index: number; text: string; cacheKey: string }> = []
   const transliterationPrefix = useTransliteration ? 'transliteration:' : ''
+  const modLogPrefix = context?.modName ? `[모드:${context.modName}] ` : ''
 
   for (const [index, text] of texts.entries()) {
     if (!text || text.trim() === '') {
@@ -303,7 +309,7 @@ export async function translateBulk (
     if (hasDictionary(normalizedText, gameType)) {
       const dictionaryTranslatedText = sanitizeTranslationText(getDictionary(normalizedText, gameType)!)
       results[index] = { translatedText: dictionaryTranslatedText }
-      log.info(`[벌크/${index}] 사전 응답 사용: ${normalizedText} -> ${dictionaryTranslatedText}${useTransliteration ? ' (음역 모드)' : ''}`)
+      log.info(`${modLogPrefix}[벌크/${index}] 사전 응답 사용: ${normalizedText} -> ${dictionaryTranslatedText}${useTransliteration ? ' (음역 모드)' : ''}`)
       continue
     }
 
@@ -319,7 +325,7 @@ export async function translateBulk (
         const { isValid } = validateTranslation(normalizedText, sanitizedCached, gameType)
         if (isValid) {
           results[index] = { translatedText: sanitizedCached }
-          log.info(`[벌크/${index}] 캐시 응답 사용: ${normalizedText} -> ${sanitizedCached}${useTransliteration ? ' (음역 모드)' : ''}`)
+          log.info(`${modLogPrefix}[벌크/${index}] 캐시 응답 사용: ${normalizedText} -> ${sanitizedCached}${useTransliteration ? ' (음역 모드)' : ''}`)
           continue
         }
 
@@ -335,10 +341,10 @@ export async function translateBulk (
   }
 
   try {
-    log.info(`[벌크] AI 벌크 요청 전송: items=${unresolved.length}, gameType=${gameType}${useTransliteration ? ' (음역 모드)' : ''}`)
+    log.info(`${modLogPrefix}[벌크] AI 벌크 요청 전송: items=${unresolved.length}, gameType=${gameType}${useTransliteration ? ' (음역 모드)' : ''}`)
 
     for (const unresolvedItem of unresolved) {
-      log.info(`[벌크/${unresolvedItem.index}] AI 벌크 요청에 포함: ${unresolvedItem.text}${useTransliteration ? ' (음역 모드)' : ''}`)
+      log.info(`${modLogPrefix}[벌크/${unresolvedItem.index}] AI 벌크 요청에 포함: ${unresolvedItem.text}${useTransliteration ? ' (음역 모드)' : ''}`)
     }
 
     const aiTranslated = await translateAIBulk(unresolved.map(item => item.text), gameType, useTransliteration)
@@ -350,32 +356,32 @@ export async function translateBulk (
       if (validation.isValid) {
         await setCache(unresolvedItem.cacheKey, translatedText, gameType)
         results[unresolvedItem.index] = { translatedText }
-        log.info(`[벌크/${unresolvedItem.index}] AI 응답 처리: ${unresolvedItem.text} -> ${translatedText}${useTransliteration ? ' (음역 모드)' : ''}`)
+        log.info(`${modLogPrefix}[벌크/${unresolvedItem.index}] AI 응답 처리: ${unresolvedItem.text} -> ${translatedText}${useTransliteration ? ' (음역 모드)' : ''}`)
       } else {
-        log.warn(`[벌크/${unresolvedItem.index}] AI 응답 검증 실패, 개별 번역으로 재시도: ${unresolvedItem.text} -> ${translatedText} (사유: ${validation.reason})`)
+        log.warn(`${modLogPrefix}[벌크/${unresolvedItem.index}] AI 응답 검증 실패, 개별 번역으로 재시도: ${unresolvedItem.text} -> ${translatedText} (사유: ${validation.reason})`)
         // 검증 실패 시 개별 번역으로 재시도
         const fallback = await translate(unresolvedItem.text, gameType, 0, undefined, useTransliteration)
         results[unresolvedItem.index] = { translatedText: fallback }
-        log.info(`[벌크/${unresolvedItem.index}] 개별 재시도 응답 처리: ${unresolvedItem.text} -> ${fallback}${useTransliteration ? ' (음역 모드)' : ''}`)
+        log.info(`${modLogPrefix}[벌크/${unresolvedItem.index}] 개별 재시도 응답 처리: ${unresolvedItem.text} -> ${fallback}${useTransliteration ? ' (음역 모드)' : ''}`)
       }
     }
   } catch (error) {
     const errorInfo = error instanceof Error ? error : String(error)
     log.warn(
-      `[벌크] AI 벌크 요청 실패, 개별 번역으로 폴백${useTransliteration ? ' (음역 모드)' : ''}`,
+      `${modLogPrefix}[벌크] AI 벌크 요청 실패, 개별 번역으로 폴백${useTransliteration ? ' (음역 모드)' : ''}`,
       errorInfo
     )
     // 벌크 요청 실패 시 개별 번역으로 폴백
     for (const unresolvedItem of unresolved) {
       try {
-        log.info(`[벌크/${unresolvedItem.index}] 개별 폴백 요청: ${unresolvedItem.text}${useTransliteration ? ' (음역 모드)' : ''}`)
+        log.info(`${modLogPrefix}[벌크/${unresolvedItem.index}] 개별 폴백 요청: ${unresolvedItem.text}${useTransliteration ? ' (음역 모드)' : ''}`)
         const translatedText = await translate(unresolvedItem.text, gameType, 0, undefined, useTransliteration)
         results[unresolvedItem.index] = { translatedText }
-        log.info(`[벌크/${unresolvedItem.index}] 개별 폴백 응답 처리: ${unresolvedItem.text} -> ${translatedText}${useTransliteration ? ' (음역 모드)' : ''}`)
+        log.info(`${modLogPrefix}[벌크/${unresolvedItem.index}] 개별 폴백 응답 처리: ${unresolvedItem.text} -> ${translatedText}${useTransliteration ? ' (음역 모드)' : ''}`)
       } catch (error) {
         if (error instanceof TranslationRefusedError || error instanceof TranslationRetryExceededError) {
           results[unresolvedItem.index] = { translatedText: unresolvedItem.text, error }
-          log.warn(`[벌크/${unresolvedItem.index}] 개별 폴백 실패, 원문 유지: ${unresolvedItem.text} (사유: ${(error as Error).message})`)
+          log.warn(`${modLogPrefix}[벌크/${unresolvedItem.index}] 개별 폴백 실패, 원문 유지: ${unresolvedItem.text} (사유: ${(error as Error).message})`)
         } else {
           throw error
         }


### PR DESCRIPTION
### Motivation
- 벌크 번역에서 JSON 파싱 실패 또는 AI 응답 실패가 발생했을 때 실제 AI 응답 내용을 로그에 포함해 원인 파악을 쉽게 하기 위함입니다.
- 벌크 작업이 병렬로 실행되므로 로그에 모드명을 추가해 어떤 모드에서 발생한 로그인지 명확히 표시하려는 의도입니다.

### Description
- `parseBulkResponse`에서 JSON 파싱 실패 시 에러 메시지에 공백 정규화된 `AI 응답 원문` 미리보기를 최대 500자까지 포함하도록 개선했습니다 (`scripts/utils/ai.ts`).
- `translateBulk`에 선택적 컨텍스트 파라미터 `context?: { modName?: string }`를 추가하고, 벌크 관련 `info`/`warn` 로그 앞에 `[모드:<modName>]` 접두사를 붙이도록 변경했습니다 (`scripts/utils/translate.ts`).
- 팩토리 레이어에서 `translateBulk` 호출 시 현재 모드명을 전달하도록 수정해 병렬 모드 처리 시 로그 상관관계를 확보했습니다 (`scripts/factory/translate.ts`).
- 관련 단위 테스트를 보강해 `parseBulkResponse` 파싱 실패 시 에러 메시지에 `AI 응답 원문:` 포함 여부와, 벌크 실패 폴백 로그에 `[모드:<name>]` 접두사 포함 여부를 검증하도록 수정했습니다 (`scripts/utils/ai.test.ts`, `scripts/utils/translate.test.ts`).

### Testing
- `pnpm test`를 실행해 전체 테스트 스위트가 통과함을 확인했습니다 (`Tests 451 passed`).
- 수정한 테스트 파일: `scripts/utils/ai.test.ts` 및 `scripts/utils/translate.test.ts`가 포함되어 있으며 해당 테스트들이 성공했습니다.
- `pnpm lint`는 레포지토리에 `lint` 스크립트가 정의되어 있지 않아 실행되지 않았습니다 (`Command "lint" not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7662509608331b3d1a69c8e9841f1)