### PR TITLE
fix: 벌크 번역 요청 배치 분할 및 JSON 응답 안정화

### DIFF
--- a/scripts/utils/ai.ts
+++ b/scripts/utils/ai.ts
@@ -113,7 +113,18 @@ Please provide a corrected translation that addresses the issue mentioned above.
       }
 
       try {
-        const { response } = await model.generateContent(prompt)
+        const { response } = await model.generateContent({
+          contents: [
+            {
+              role: 'user',
+              parts: [{ text: prompt }],
+            },
+          ],
+          generationConfig: {
+            ...generationConfig,
+            responseMimeType: 'application/json',
+          },
+        })
 
         // 프롬프트 차단 확인
         const promptFeedback = response.promptFeedback

--- a/scripts/utils/translate.test.ts
+++ b/scripts/utils/translate.test.ts
@@ -566,4 +566,17 @@ describe('translateBulk', () => {
     expect(results).toEqual([{ translatedText: '[캐시번역]cached' }])
     expectInfoLogContains(vi.mocked(log.info), '[벌크/0]', 'cached', '[캐시번역]cached')
   })
+
+  it('벌크 대상이 많으면 여러 배치로 나누어 요청해야 함', async () => {
+    const { translateBulk } = await import('./translate')
+    const { translateAIBulk } = await import('./ai')
+
+    const texts = Array.from({ length: 25 }, (_, index) => `item-${index + 1}`)
+    const results = await translateBulk(texts, 'ck3', false)
+
+    expect(results).toHaveLength(25)
+    expect(translateAIBulk).toHaveBeenCalledTimes(2)
+    expect(vi.mocked(translateAIBulk).mock.calls[0][0]).toHaveLength(24)
+    expect(vi.mocked(translateAIBulk).mock.calls[1][0]).toHaveLength(1)
+  })
 })

--- a/scripts/utils/translate.ts
+++ b/scripts/utils/translate.ts
@@ -23,6 +23,43 @@ interface BulkTranslateContext {
   modName?: string
 }
 
+const MAX_BULK_ITEMS_PER_REQUEST = 24
+const MAX_BULK_CHARS_PER_REQUEST = 6000
+
+interface UnresolvedBulkItem {
+  index: number
+  text: string
+  cacheKey: string
+}
+
+function splitBulkRequests(items: UnresolvedBulkItem[]): UnresolvedBulkItem[][] {
+  const batches: UnresolvedBulkItem[][] = []
+  let currentBatch: UnresolvedBulkItem[] = []
+  let currentChars = 0
+
+  for (const item of items) {
+    const itemChars = item.text.length
+    const shouldSplit =
+      currentBatch.length > 0 &&
+      (currentBatch.length >= MAX_BULK_ITEMS_PER_REQUEST || currentChars + itemChars > MAX_BULK_CHARS_PER_REQUEST)
+
+    if (shouldSplit) {
+      batches.push(currentBatch)
+      currentBatch = []
+      currentChars = 0
+    }
+
+    currentBatch.push(item)
+    currentChars += itemChars
+  }
+
+  if (currentBatch.length > 0) {
+    batches.push(currentBatch)
+  }
+
+  return batches
+}
+
 /**
  * Regex patterns for detecting variable-only text that should be returned immediately without AI translation.
  * 
@@ -280,7 +317,7 @@ export async function translateBulk (
   }
 
   const results: BulkTranslateResult[] = Array.from({ length: texts.length }, () => ({ translatedText: '' }))
-  const unresolved: Array<{ index: number; text: string; cacheKey: string }> = []
+  const unresolved: UnresolvedBulkItem[] = []
   const transliterationPrefix = useTransliteration ? 'transliteration:' : ''
   const modLogPrefix = context?.modName ? `[모드:${context.modName}] ` : ''
 
@@ -340,50 +377,56 @@ export async function translateBulk (
     return results
   }
 
-  try {
-    log.info(`${modLogPrefix}[벌크] AI 벌크 요청 전송: items=${unresolved.length}, gameType=${gameType}${useTransliteration ? ' (음역 모드)' : ''}`)
+  const batches = splitBulkRequests(unresolved)
 
-    for (const unresolvedItem of unresolved) {
-      log.info(`${modLogPrefix}[벌크/${unresolvedItem.index}] AI 벌크 요청에 포함: ${unresolvedItem.text}${useTransliteration ? ' (음역 모드)' : ''}`)
-    }
+  for (const [batchIndex, batch] of batches.entries()) {
+    try {
+      log.info(
+        `${modLogPrefix}[벌크] AI 벌크 요청 전송: batch=${batchIndex + 1}/${batches.length}, items=${batch.length}, gameType=${gameType}${useTransliteration ? ' (음역 모드)' : ''}`
+      )
 
-    const aiTranslated = await translateAIBulk(unresolved.map(item => item.text), gameType, useTransliteration)
-
-    for (const [bulkIndex, unresolvedItem] of unresolved.entries()) {
-      const translatedText = sanitizeTranslationText(aiTranslated[bulkIndex] || unresolvedItem.text)
-      const validation = validateTranslation(unresolvedItem.text, translatedText, gameType)
-
-      if (validation.isValid) {
-        await setCache(unresolvedItem.cacheKey, translatedText, gameType)
-        results[unresolvedItem.index] = { translatedText }
-        log.info(`${modLogPrefix}[벌크/${unresolvedItem.index}] AI 응답 처리: ${unresolvedItem.text} -> ${translatedText}${useTransliteration ? ' (음역 모드)' : ''}`)
-      } else {
-        log.warn(`${modLogPrefix}[벌크/${unresolvedItem.index}] AI 응답 검증 실패, 개별 번역으로 재시도: ${unresolvedItem.text} -> ${translatedText} (사유: ${validation.reason})`)
-        // 검증 실패 시 개별 번역으로 재시도
-        const fallback = await translate(unresolvedItem.text, gameType, 0, undefined, useTransliteration)
-        results[unresolvedItem.index] = { translatedText: fallback }
-        log.info(`${modLogPrefix}[벌크/${unresolvedItem.index}] 개별 재시도 응답 처리: ${unresolvedItem.text} -> ${fallback}${useTransliteration ? ' (음역 모드)' : ''}`)
+      for (const unresolvedItem of batch) {
+        log.info(`${modLogPrefix}[벌크/${unresolvedItem.index}] AI 벌크 요청에 포함: ${unresolvedItem.text}${useTransliteration ? ' (음역 모드)' : ''}`)
       }
-    }
-  } catch (error) {
-    const errorInfo = error instanceof Error ? error : String(error)
-    log.warn(
-      `${modLogPrefix}[벌크] AI 벌크 요청 실패, 개별 번역으로 폴백${useTransliteration ? ' (음역 모드)' : ''}`,
-      errorInfo
-    )
-    // 벌크 요청 실패 시 개별 번역으로 폴백
-    for (const unresolvedItem of unresolved) {
-      try {
-        log.info(`${modLogPrefix}[벌크/${unresolvedItem.index}] 개별 폴백 요청: ${unresolvedItem.text}${useTransliteration ? ' (음역 모드)' : ''}`)
-        const translatedText = await translate(unresolvedItem.text, gameType, 0, undefined, useTransliteration)
-        results[unresolvedItem.index] = { translatedText }
-        log.info(`${modLogPrefix}[벌크/${unresolvedItem.index}] 개별 폴백 응답 처리: ${unresolvedItem.text} -> ${translatedText}${useTransliteration ? ' (음역 모드)' : ''}`)
-      } catch (error) {
-        if (error instanceof TranslationRefusedError || error instanceof TranslationRetryExceededError) {
-          results[unresolvedItem.index] = { translatedText: unresolvedItem.text, error }
-          log.warn(`${modLogPrefix}[벌크/${unresolvedItem.index}] 개별 폴백 실패, 원문 유지: ${unresolvedItem.text} (사유: ${(error as Error).message})`)
+
+      const aiTranslated = await translateAIBulk(batch.map(item => item.text), gameType, useTransliteration)
+
+      for (const [bulkIndex, unresolvedItem] of batch.entries()) {
+        const translatedText = sanitizeTranslationText(aiTranslated[bulkIndex] || unresolvedItem.text)
+        const validation = validateTranslation(unresolvedItem.text, translatedText, gameType)
+
+        if (validation.isValid) {
+          await setCache(unresolvedItem.cacheKey, translatedText, gameType)
+          results[unresolvedItem.index] = { translatedText }
+          log.info(`${modLogPrefix}[벌크/${unresolvedItem.index}] AI 응답 처리: ${unresolvedItem.text} -> ${translatedText}${useTransliteration ? ' (음역 모드)' : ''}`)
         } else {
-          throw error
+          log.warn(`${modLogPrefix}[벌크/${unresolvedItem.index}] AI 응답 검증 실패, 개별 번역으로 재시도: ${unresolvedItem.text} -> ${translatedText} (사유: ${validation.reason})`)
+          // 검증 실패 시 개별 번역으로 재시도
+          const fallback = await translate(unresolvedItem.text, gameType, 0, undefined, useTransliteration)
+          results[unresolvedItem.index] = { translatedText: fallback }
+          log.info(`${modLogPrefix}[벌크/${unresolvedItem.index}] 개별 재시도 응답 처리: ${unresolvedItem.text} -> ${fallback}${useTransliteration ? ' (음역 모드)' : ''}`)
+        }
+      }
+    } catch (error) {
+      const errorInfo = error instanceof Error ? error : String(error)
+      log.warn(
+        `${modLogPrefix}[벌크] AI 벌크 요청 실패, 개별 번역으로 폴백: batch=${batchIndex + 1}/${batches.length}${useTransliteration ? ' (음역 모드)' : ''}`,
+        errorInfo
+      )
+      // 벌크 요청 실패 시 해당 배치만 개별 번역으로 폴백
+      for (const unresolvedItem of batch) {
+        try {
+          log.info(`${modLogPrefix}[벌크/${unresolvedItem.index}] 개별 폴백 요청: ${unresolvedItem.text}${useTransliteration ? ' (음역 모드)' : ''}`)
+          const translatedText = await translate(unresolvedItem.text, gameType, 0, undefined, useTransliteration)
+          results[unresolvedItem.index] = { translatedText }
+          log.info(`${modLogPrefix}[벌크/${unresolvedItem.index}] 개별 폴백 응답 처리: ${unresolvedItem.text} -> ${translatedText}${useTransliteration ? ' (음역 모드)' : ''}`)
+        } catch (error) {
+          if (error instanceof TranslationRefusedError || error instanceof TranslationRetryExceededError) {
+            results[unresolvedItem.index] = { translatedText: unresolvedItem.text, error }
+            log.warn(`${modLogPrefix}[벌크/${unresolvedItem.index}] 개별 폴백 실패, 원문 유지: ${unresolvedItem.text} (사유: ${(error as Error).message})`)
+          } else {
+            throw error
+          }
         }
       }
     }


### PR DESCRIPTION
### Motivation
- 대용량/장문을 한 번에 AI 벌크 요청할 때 응답이 잘리거나 JSON이 깨져 파싱 에러(Unterminated string / invalid JSON)가 반복되어 안정성 개선이 필요했습니다.
- 전체 벌크가 실패하면 모든 항목을 개별 폴백하는 현재 방식은 성능 저하와 로그 노이즈를 유발했습니다.

### Description
- `translateBulk`가 미해결 항목을 `MAX_BULK_ITEMS_PER_REQUEST = 24` 또는 `MAX_BULK_CHARS_PER_REQUEST = 6000` 기준으로 분할하도록 `splitBulkRequests`를 추가했습니다 (`scripts/utils/translate.ts`).
- 배치별로 AI 요청을 보내고 실패할 경우 해당 배치만 개별 폴백하도록 변경해 전체 실패 범위를 줄였습니다 (`scripts/utils/translate.ts`).
- 벌크 요청 로그에 `batch=current/total` 정보를 추가해 실패 지점을 쉽게 추적할 수 있게 했습니다 (`scripts/utils/translate.ts`).
- AI 호출에서 JSON 응답 일관성을 높이기 위해 `model.generateContent` 호출에 `contents` 구조와 `generationConfig.responseMimeType = 'application/json'`를 명시하도록 변경했습니다 (`scripts/utils/ai.ts`).
- 배치 분할 동작을 검증하는 단위 테스트를 추가했습니다 (`scripts/utils/translate.test.ts`).

### Testing
- 타입 검사: `pnpm exec tsc --noEmit` 명령을 실행해 성공했습니다.
- 단위 테스트: `pnpm test`를 실행해 전체 테스트가 성공했고 총 452개의 테스트가 모두 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c767e361e4833182c4c0be1dcb8f67)