### PR TITLE
fix: 주간 Codex 워크플로 프롬프트 전달 방식 수정

### DIFF
--- a/.github/workflows/weekly-codex-refactor.yml
+++ b/.github/workflows/weekly-codex-refactor.yml
@@ -51,9 +51,7 @@ jobs:
 
       - name: Codex로 주간 리팩토링 수행
         run: |
-          PROMPT_FILE=$(mktemp)
-          trap 'rm -f "$PROMPT_FILE"' EXIT
-          cat <<'EOF' > "$PROMPT_FILE"
+          PROMPT=$(cat <<'EOF'
           당신은 이 저장소의 유지보수 담당 엔지니어입니다.
 
           목표:
@@ -69,11 +67,12 @@ jobs:
           - 불필요한 파일은 생성하지 않는다.
           - 개선 사항이 없으면 파일을 수정하지 않는다.
           EOF
+          )
 
           codex exec \
             --cd "$GITHUB_WORKSPACE" \
             --sandbox workspace-write \
-            --prompt-file "$PROMPT_FILE"
+            "$PROMPT"
 
       - name: 변경사항 린트 검증
         run: pnpm exec tsc --noEmit


### PR DESCRIPTION
### Motivation
- Codex CLI의 `--prompt-file` 방식이 일부 환경에서 옵션 파싱 오류로 워크플로가 실패하는 경우를 줄이기 위해 프롬프트 전달 방식을 안정화했습니다.

### Description
- `.github/workflows/weekly-codex-refactor.yml`에서 임시 파일로 프롬프트를 생성하고 `--prompt-file`로 전달하던 부분을 멀티라인 문자열을 셸 변수(`PROMPT`)로 구성해 `codex exec`에 직접 인자로 전달하도록 변경했습니다.

### Testing
- `pnpm exec tsc --noEmit`와 `pnpm test`를 실행해 린트와 모든 자동화 테스트가 통과했음을 확인했습니다 (Vitest: 452 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c76bfa5c28833192460ac2b433ffe2)