### PR TITLE
ci(workflow): make Codex sandbox configurable, add sandbox retry and PR error guidance

### DIFF
--- a/.github/workflows/weekly-codex-refactor.yml
+++ b/.github/workflows/weekly-codex-refactor.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       LOG_LEVEL: "${{ vars.LOG_LEVEL }}"
       CODEX_HOME: "${{ github.workspace }}/.codex-home"
+      CODEX_SANDBOX_MODE: "${{ vars.CODEX_SANDBOX_MODE || 'workspace-write' }}"
     steps:
       - name: 저장소 체크아웃
         uses: actions/checkout@v6
@@ -69,10 +70,30 @@ jobs:
           EOF
           )
 
+          LOG_FILE="$(mktemp)"
+          set +e
           codex exec \
             --cd "$GITHUB_WORKSPACE" \
-            --sandbox workspace-write \
-            "$PROMPT"
+            --sandbox "$CODEX_SANDBOX_MODE" \
+            "$PROMPT" 2>&1 | tee "$LOG_FILE"
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            exit 0
+          fi
+
+          if grep -q "bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted" "$LOG_FILE"; then
+            echo "::warning::기본 샌드박스($CODEX_SANDBOX_MODE)에서 bwrap 오류가 발생해 danger-full-access로 1회 재시도합니다."
+            codex exec \
+              --cd "$GITHUB_WORKSPACE" \
+              --sandbox danger-full-access \
+              "$PROMPT"
+            exit 0
+          fi
+
+          echo "::error::Codex 실행에 실패했습니다. 로그를 확인하세요."
+          exit "$EXIT_CODE"
 
       - name: 변경사항 린트 검증
         run: pnpm exec tsc --noEmit
@@ -85,8 +106,11 @@ jobs:
         run: rm -f "$CODEX_HOME/auth.json"
 
       - name: 자동 리팩토링 PR 생성
+        id: create_pr
+        continue-on-error: true
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.CI_GITHUB_TOKEN != '' && secrets.CI_GITHUB_TOKEN || github.token }}
           branch: chore/weekly-codex-refactor
           delete-branch: true
           commit-message: "chore: 주간 Codex 자동 리팩토링"
@@ -103,3 +127,8 @@ jobs:
           labels: |
             automation
             codex
+
+      - name: PR 생성 실패 안내
+        if: steps.create_pr.outcome != 'success'
+        run: |
+          echo "::warning::자동 PR 생성에 실패했습니다. 저장소 설정에서 'Allow GitHub Actions to create and approve pull requests'를 켜거나 CI_GITHUB_TOKEN 시크릿(PAT, repo 권한)을 설정하세요."


### PR DESCRIPTION
### Motivation
- Make the Codex execution sandbox configurable and increase robustness against bwrap permission failures when running the weekly refactor job.
- Improve diagnostic output by capturing Codex logs and surfacing clearer errors and retry behavior for known sandbox issues.
- Avoid blocking the workflow on PR creation failures and provide actionable guidance when Actions lacks PR creation permissions.

### Description
- Add `CODEX_SANDBOX_MODE` env var (default `workspace-write`) and pass it to `codex exec` via `--sandbox`.
- Capture Codex stdout/stderr to a temporary log file and preserve the `codex exec` exit code using `PIPESTATUS` so the job can inspect failures.
- On non-zero exit, detect the `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted` error and retry once with `--sandbox danger-full-access` before failing.
- Temporarily allow `codex exec` to fail (`set +e`) while inspecting logs and then restore `set -e` after handling.
- Make the PR creation step use an explicit token fallback (`${{ secrets.CI_GITHUB_TOKEN != '' && secrets.CI_GITHUB_TOKEN || github.token }}`), add `id: create_pr` and `continue-on-error: true`, and add a follow-up step that warns with instructions when PR creation fails.

### Testing
- The workflow executes `pnpm exec tsc --noEmit` and `pnpm test` as part of the job (these steps are unchanged).
- This change only modifies the GitHub Actions workflow file, so no repository code tests were executed locally as part of this edit; the CI workflow will run the typecheck and test suite when triggered.
- No automated test failures are introduced by the workflow edits themselves; runtime behavior (sandbox retry and PR creation) will be validated by subsequent CI runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c76d787a9483319228601e91c0b645)