### PR TITLE
feat: 업스트림 파일 해시 기반 번역 스킵 로직 추가

### DIFF
--- a/scripts/factory/translate.test.ts
+++ b/scripts/factory/translate.test.ts
@@ -1243,6 +1243,124 @@ language = "english"
     // 정리
     await rm(testDir, { recursive: true, force: true })
   })
+
+  it('업스트림 파일 해시를 저장해야 함', async () => {
+    const { processModTranslations } = await import('./translate')
+
+    const modDir = join(testDir, 'test-mod')
+    const upstreamDir = join(modDir, 'upstream')
+    const metaContent = `
+[upstream]
+localization = ["."]
+language = "english"
+`
+    await mkdir(upstreamDir, { recursive: true })
+    await writeFile(join(modDir, 'meta.toml'), metaContent, 'utf-8')
+    await writeFile(
+      join(upstreamDir, 'hash-target_l_english.yml'),
+      `l_english:
+  key_a: "alpha"
+  key_b: "beta"`,
+      'utf-8'
+    )
+
+    await processModTranslations({
+      rootDir: testDir,
+      mods: ['test-mod'],
+      gameType: 'ck3',
+      onlyHash: false
+    })
+
+    const hashIndexPath = join(upstreamDir, '.pat-file-hashes.json')
+    const hashIndex = JSON.parse(await readFile(hashIndexPath, 'utf-8')) as Record<string, string>
+
+    expect(Object.keys(hashIndex)).toContain('hash-target_l_english.yml')
+    expect(typeof hashIndex['hash-target_l_english.yml']).toBe('string')
+    expect(hashIndex['hash-target_l_english.yml'].length).toBeGreaterThan(0)
+  })
+
+  it('업스트림 파일 해시가 같으면 해당 파일 번역을 건너뛰어야 함', async () => {
+    const { processModTranslations } = await import('./translate')
+    const { translateBulk } = await import('../utils/translate')
+
+    const modDir = join(testDir, 'test-mod')
+    const upstreamDir = join(modDir, 'upstream')
+    const metaContent = `
+[upstream]
+localization = ["."]
+language = "english"
+`
+    await mkdir(upstreamDir, { recursive: true })
+    await writeFile(join(modDir, 'meta.toml'), metaContent, 'utf-8')
+    await writeFile(
+      join(upstreamDir, 'same-hash_l_english.yml'),
+      `l_english:
+  key_1: "hello"
+  key_2: "world"`,
+      'utf-8'
+    )
+
+    await processModTranslations({
+      rootDir: testDir,
+      mods: ['test-mod'],
+      gameType: 'ck3',
+      onlyHash: false
+    })
+
+    const firstRunCallCount = vi.mocked(translateBulk).mock.calls.length
+    expect(firstRunCallCount).toBeGreaterThan(0)
+
+    await processModTranslations({
+      rootDir: testDir,
+      mods: ['test-mod'],
+      gameType: 'ck3',
+      onlyHash: false
+    })
+
+    const secondRunCallCount = vi.mocked(translateBulk).mock.calls.length
+    expect(secondRunCallCount).toBe(firstRunCallCount)
+  })
+
+  it('업스트림 파일 해시가 변경된 파일만 다시 번역해야 함', async () => {
+    const { processModTranslations } = await import('./translate')
+    const { translateBulk } = await import('../utils/translate')
+
+    const modDir = join(testDir, 'test-mod')
+    const upstreamDir = join(modDir, 'upstream')
+    const metaContent = `
+[upstream]
+localization = ["."]
+language = "english"
+`
+    await mkdir(upstreamDir, { recursive: true })
+    await writeFile(join(modDir, 'meta.toml'), metaContent, 'utf-8')
+
+    const stableFilePath = join(upstreamDir, 'stable_l_english.yml')
+    const changedFilePath = join(upstreamDir, 'changed_l_english.yml')
+    await writeFile(stableFilePath, `l_english:\n  key_stable: "stable text"`, 'utf-8')
+    await writeFile(changedFilePath, `l_english:\n  key_changed: "first text"`, 'utf-8')
+
+    await processModTranslations({
+      rootDir: testDir,
+      mods: ['test-mod'],
+      gameType: 'ck3',
+      onlyHash: false
+    })
+
+    const firstRunCallCount = vi.mocked(translateBulk).mock.calls.length
+
+    await writeFile(changedFilePath, `l_english:\n  key_changed: "updated text"`, 'utf-8')
+
+    await processModTranslations({
+      rootDir: testDir,
+      mods: ['test-mod'],
+      gameType: 'ck3',
+      onlyHash: false
+    })
+
+    const secondRunCallCount = vi.mocked(translateBulk).mock.calls.length
+    expect(secondRunCallCount).toBe(firstRunCallCount + 1)
+  })
 })
 
 // 지정된 개수의 항목을 가진 YAML 파일을 생성하는 헬퍼 함수

--- a/scripts/factory/translate.ts
+++ b/scripts/factory/translate.ts
@@ -92,6 +92,10 @@ interface ModMeta {
   };
 }
 
+type UpstreamFileHashMap = Record<string, string>
+
+const UPSTREAM_FILE_HASHES_FILENAME = '.pat-file-hashes.json'
+
 export interface UntranslatedItem {
   mod: string
   file: string
@@ -117,6 +121,27 @@ function resolveLogModName(modName: string, filePath: string): string {
   const normalizedPath = filePath.replace(/\\/g, '/')
   const [actualModName] = normalizedPath.split('/')
   return actualModName || modName
+}
+
+async function readUpstreamFileHashes(hashFilePath: string): Promise<UpstreamFileHashMap> {
+  try {
+    const content = await readFile(hashFilePath, 'utf-8')
+    const parsed = JSON.parse(content)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {}
+    }
+    return parsed as UpstreamFileHashMap
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {}
+    }
+    log.warn(`업스트림 파일 해시를 읽는 중 오류가 발생해 초기 상태로 진행합니다: ${hashFilePath}`)
+    return {}
+  }
+}
+
+async function writeUpstreamFileHashes(hashFilePath: string, hashes: UpstreamFileHashMap): Promise<void> {
+  await writeFile(hashFilePath, `${JSON.stringify(hashes, null, 2)}\n`, 'utf-8')
 }
 
 export async function processModTranslations ({ rootDir, mods, gameType, onlyHash = false, timeoutMinutes }: ModTranslationsOptions): Promise<TranslationResult> {
@@ -153,6 +178,11 @@ export async function processModTranslations ({ rootDir, mods, gameType, onlyHas
 
     const metaContent = await readFile(metaPath, 'utf-8')
     const meta = parseToml(metaContent) as ModMeta
+    const hashFilePath = join(modDir, 'upstream', UPSTREAM_FILE_HASHES_FILENAME)
+    const savedFileHashes = await readUpstreamFileHashes(hashFilePath)
+    const nextFileHashes: UpstreamFileHashMap = { ...savedFileHashes }
+    const currentSourcePaths = new Set<string>()
+    let hasHashChanges = false
     log.debug(`[${mod}] 메타데이터:  upstream.language: ${meta.upstream.language}, upstream.localization: [${meta.upstream.localization}]`)
 
     for (const locPath of meta.upstream.localization) {
@@ -210,7 +240,23 @@ export async function processModTranslations ({ rootDir, mods, gameType, onlyHas
       for (const file of sourceFiles) {
         // 언어파일 이름이 `_l_언어코드.yml` 형식이면 처리
         if (file.endsWith(`.yml`) && file.includes(`_l_${meta.upstream.language}`)) {
-          processes.push(processLanguageFile(mod, sourceDir, targetDir, file, meta.upstream.language, gameType, onlyHash, startTime, timeoutMs, projectRoot, meta.upstream.transliteration_files))
+          const sourcePath = join(sourceDir, file)
+          const sourceContent = await readFile(sourcePath, 'utf-8')
+          const sourceFileHash = hashing(sourceContent)
+          const sourceRelativePath = join(locPath, file).replace(/\\/g, '/')
+          currentSourcePaths.add(sourceRelativePath)
+          const previousFileHash = savedFileHashes[sourceRelativePath]
+
+          if (!onlyHash && previousFileHash === sourceFileHash) {
+            log.debug(`[${mod}/${file}] 업스트림 파일 해시 일치로 번역 건너뜀: ${sourceFileHash}`)
+          } else {
+            processes.push(processLanguageFile(mod, sourceDir, targetDir, file, meta.upstream.language, gameType, onlyHash, startTime, timeoutMs, projectRoot, meta.upstream.transliteration_files))
+          }
+
+          if (nextFileHashes[sourceRelativePath] !== sourceFileHash) {
+            nextFileHashes[sourceRelativePath] = sourceFileHash
+            hasHashChanges = true
+          }
           // 처리될 한국어 파일 경로 추적
           const targetParentDir = join(targetDir, dirname(file))
           const targetFileName = '___' + basename(file).replace(`_l_${meta.upstream.language}.yml`, '_l_korean.yml')
@@ -229,6 +275,17 @@ export async function processModTranslations ({ rootDir, mods, gameType, onlyHas
     // 모든 파일 처리 완료 후 orphaned 파일 정리
     for (const task of locPathCleanupTasks) {
       await cleanupOrphanedFiles(task.targetDir, task.expectedKoreanFiles, task.mod, task.locPath, projectRoot)
+    }
+
+    for (const savedPath of Object.keys(nextFileHashes)) {
+      if (!currentSourcePaths.has(savedPath)) {
+        delete nextFileHashes[savedPath]
+        hasHashChanges = true
+      }
+    }
+
+    if (hasHashChanges) {
+      await writeUpstreamFileHashes(hashFilePath, nextFileHashes)
     }
     
     const untranslatedItems: UntranslatedItem[] = []


### PR DESCRIPTION
### Motivation
- 업스트림 파일이 변경되지 않았을 때 불필요한 번역 호출을 건너뛰어 전체 번역 시간과 비용을 줄이기 위한 목적입니다.
- 파일 단위의 변경 여부를 신뢰할 수 있는 해시로 관리함으로써 번역 일관성과 캐시 동기화를 개선하려는 의도입니다.

### Description
- 모드별 upstream 디렉토리에 `.pat-file-hashes.json` 인덱스를 도입하고 읽기/쓰기 유틸리티(`readUpstreamFileHashes`, `writeUpstreamFileHashes`)를 추가했습니다 (`scripts/factory/translate.ts`).
- 각 업스트림 파일의 내용을 `hashing`으로 계산해 기존 인덱스와 동일하면 `processLanguageFile` 호출을 건너뛰도록 변경하여 파일 단위 스킵을 구현했습니다.
- 인덱스는 신규/변경된 파일의 해시를 갱신하며, 더 이상 존재하지 않는 업스트림 파일의 엔트리는 제거해 인덱스 동기화를 수행합니다.
- 관련 회귀 테스트를 추가해 인덱스 생성, 동일 해시 시 스킵 동작, 변경된 파일만 재번역되는 동작을 검증했습니다 (`scripts/factory/translate.test.ts`에 테스트 추가).

### Testing
- 모든 자동화된 테스트를 실행하여 문제 없음이 확인되었습니다: `pnpm test` → 전체 테스트 통과 (468 passed).
- 타입 체크 실행: `pnpm exec tsc --noEmit` → 성공.
- 추가된 회귀 테스트(해시 인덱스 생성/동작 검증 포함)는 테스트 스위트에서 모두 통과했음을 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c78917f5b883318d1b899574d8dbb2)