### PR TITLE
fix: 점(.) 구분자 desc/event/decision 키 음역 검증 제외

### DIFF
--- a/scripts/utils/prompts.test.ts
+++ b/scripts/utils/prompts.test.ts
@@ -254,6 +254,13 @@ describe('isRegularTranslationContext', () => {
     expect(isRegularTranslationContext('CULTURE_EVENT')).toBe(true)
   })
 
+
+  it('점(.) 구분자로 끝나는 desc/event/decision 키도 일반 번역 컨텍스트여야 함', () => {
+    expect(isRegularTranslationContext('red_sea.0050.desc')).toBe(true)
+    expect(isRegularTranslationContext('rice_event.0001.event')).toBe(true)
+    expect(isRegularTranslationContext('my_mod.1234.decision')).toBe(true)
+  })
+
   it('일반 키는 일반 번역 컨텍스트가 아니어야 함', () => {
     expect(isRegularTranslationContext('modifier')).toBe(false)
     expect(isRegularTranslationContext('dynasty_name')).toBe(false)

--- a/scripts/utils/prompts.ts
+++ b/scripts/utils/prompts.ts
@@ -200,7 +200,7 @@ export function shouldUseTransliteration(filename: string, key?: string, manualL
  * @returns 일반 번역 컨텍스트이면 true
  */
 export function isRegularTranslationContext(key: string): boolean {
-  return /(?:^|_)(decision|desc|event)$/.test(key.toLowerCase())
+  return /(?:^|[_.])(decision|desc|event)$/.test(key.toLowerCase())
 }
 
 /**

--- a/scripts/utils/translation-validator.test.ts
+++ b/scripts/utils/translation-validator.test.ts
@@ -1668,6 +1668,20 @@ describe('음역 검증', () => {
       expect(result.length).toBe(0)
     })
 
+
+    it('점(.) 구분자로 desc로 끝나는 키는 음역 검증을 건너뛰어야 함', () => {
+      const sourceEntries = {
+        'red_sea.0050.desc': ['Very long heritage description', '']
+      }
+      const translationEntries = {
+        'red_sea.0050.desc': ['매우긴문화유산설명문장입니다', 'hash1']
+      }
+
+      const result = validateTranslationEntries(sourceEntries, translationEntries, 'ck3', true)
+
+      expect(result.length).toBe(0)
+    })
+
     it('event 키워드로 끝나는 키는 음역 검증을 건너뛰어야 함', () => {
       const sourceEntries = {
         culture_event: ['Very long event description', '']


### PR DESCRIPTION
### Motivation

- `retranslate` 경로에서 점(`.`)으로 구분된 키(예: `red_sea.0050.desc`)가 기존 `isRegularTranslationContext` 검사에서 일반 번역 컨텍스트로 인식되지 않아 음역(Transliteration) 휴리스틱 검증에 걸려 유효한 번역의 해시가 불필요하게 초기화되고 있었습니다.

### Description

- `scripts/utils/prompts.ts`의 `isRegularTranslationContext` 정규식을 `/(?:^|_)(decision|desc|event)$/`에서 `/(?:^|[_.])(decision|desc|event)$/`로 변경하여 점(`.`) 구분자도 포함되도록 수정했습니다.
- 해당 동작에 대한 회귀 방지를 위해 `scripts/utils/prompts.test.ts`에 점(`.`) 구분자 케이스를 추가했고 `scripts/utils/translation-validator.test.ts`에 점으로 끝나는 `*.desc` 키가 음역 검증에서 제외되는 테스트를 추가했습니다.
- 변경된 코드와 테스트는 `pnpm test`와 `pnpm exec tsc --noEmit`로 검증되었습니다.

### Testing

- `pnpm test` 실행 결과 모든 테스트 파일 성공으로 `472 tests passed`하며 테스트가 통과했습니다.
- `pnpm exec tsc --noEmit` 실행 결과 타입 검사도 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8d50fb450833180714bfe72e9fe86)