### PR TITLE
Re-clone upstream repository when local changes are present and add test

### DIFF
--- a/scripts/utils/upstream.test.ts
+++ b/scripts/utils/upstream.test.ts
@@ -172,6 +172,56 @@ language = "english"
     })
   })
 
+  describe('기존 저장소 업데이트', () => {
+    it('로컬 변경사항이 있으면 기존 저장소를 지우고 재클론해야 함', async () => {
+      const commands: string[] = []
+      const repoPath = join(testDir, 'ck3/TestMod/upstream')
+      await mkdir(join(repoPath, '.git'), { recursive: true })
+
+      execAsyncHandler = async (command: string) => {
+        commands.push(command)
+
+        if (command === 'git status --porcelain') {
+          return { stdout: ' M localization/english/test.yml\n', stderr: '' }
+        }
+
+        if (command.startsWith('git ls-remote --tags --refs')) {
+          return { stdout: '', stderr: '' }
+        }
+
+        if (command.startsWith('git ls-remote --symref')) {
+          return { stdout: 'ref: refs/heads/main\tHEAD\n', stderr: '' }
+        }
+
+        if (command === 'git describe --tags --exact-match') {
+          throw new Error('fatal: no tag exactly matches')
+        }
+
+        if (command === 'git rev-parse --abbrev-ref HEAD') {
+          return { stdout: 'develop\n', stderr: '' }
+        }
+
+        if (command.startsWith('git clone ')) {
+          await mkdir(join(repoPath, '.git', 'info'), { recursive: true })
+        }
+
+        return { stdout: '', stderr: '' }
+      }
+
+      const { updateUpstreamOptimized } = await import('./upstream')
+      await updateUpstreamOptimized({
+        url: 'https://github.com/test/repo.git',
+        path: 'ck3/TestMod/upstream',
+        localizationPaths: ['repo/localization/english'],
+        versionStrategy: 'default'
+      }, testDir)
+
+      expect(commands.some(command => command.startsWith('git clone '))).toBe(true)
+      expect(commands).toContain('git checkout HEAD')
+      expect(commands).not.toContain('git fetch --tags')
+    })
+  })
+
   describe('태그 clone/fetch 폴백', () => {
     it('태그 clone 실패 시 실패한 디렉토리를 정리한 뒤 기본 브랜치 clone으로 폴백해야 함', async () => {
       const commands: string[] = []

--- a/scripts/utils/upstream.ts
+++ b/scripts/utils/upstream.ts
@@ -557,7 +557,10 @@ async function updateExistingRepository(repositoryPath: string, config: Upstream
     const { stdout: status } = await execAsync('git status --porcelain', { cwd: repositoryPath })
     
     if (status.trim()) {
-      log.warn(`[${config.path}] 로컬 변경사항이 있어 업데이트를 건너뜁니다`)
+      log.warn(`[${config.path}] 로컬 변경사항이 있어 upstream 저장소를 재클론합니다`)
+      // upstream은 캐시 성격의 읽기 전용 데이터이므로, 더 안전하게 전체 재클론합니다
+      await rm(repositoryPath, { recursive: true, force: true })
+      await cloneOptimizedRepository(repositoryPath, config)
       return
     }
     


### PR DESCRIPTION
### Motivation
- Ensure upstream repositories (treated as cache/read-only data) are safely refreshed when there are local modifications instead of silently skipping updates.

### Description
- Change `updateExistingRepository` to remove the repository and call `cloneOptimizedRepository` when `git status --porcelain` reports local changes, and update the log message accordingly.
- Keep shallow-repo detection via `isShallowRepository` and existing remote ref checks intact.
- Add a unit test in `scripts/utils/upstream.test.ts` (`기존 저장소 업데이트 -> 로컬 변경사항이 있으면 기존 저장소를 지우고 재클론해야 함`) that stubs `execAsync` and asserts a `git clone` is performed and `git fetch --tags` is not called.

### Testing
- Ran the unit tests in `scripts/utils/upstream.test.ts`, including the new local-change re-clone test, and they passed.
- Ran existing tag clone/fallback tests to ensure no regressions in branch/tag fallback logic, and they remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8d4f507108331b9cb7eabc8b74660)