### PR TITLE
Potential fix for code scanning alert no. 11: Uncontrolled command line

### DIFF
--- a/scripts/utils/upstream.test.ts
+++ b/scripts/utils/upstream.test.ts
@@ -201,34 +201,35 @@ language = "english"
 
   describe('기존 저장소 업데이트', () => {
     it('로컬 변경사항이 있으면 기존 저장소를 지우고 재클론해야 함', async () => {
-      const commands: string[] = []
+      const execFileCommands: string[] = []
       const repoPath = join(testDir, 'ck3/TestMod/upstream')
       await mkdir(join(repoPath, '.git'), { recursive: true })
 
-      execAsyncHandler = async (command: string) => {
-        commands.push(command)
+      execFileAsyncHandler = async (_file: string, args: readonly string[] = []) => {
+        const cmd = [_file, ...args].join(' ')
+        execFileCommands.push(cmd)
 
-        if (command === 'git status --porcelain') {
+        if (args[0] === 'status' && args[1] === '--porcelain') {
           return { stdout: ' M localization/english/test.yml\n', stderr: '' }
         }
 
-        if (command.startsWith('git ls-remote --tags --refs')) {
+        if (args[0] === 'ls-remote' && args[1] === '--tags') {
           return { stdout: '', stderr: '' }
         }
 
-        if (command.startsWith('git ls-remote --symref')) {
+        if (args[0] === 'ls-remote' && args[1] === '--symref') {
           return { stdout: 'ref: refs/heads/main\tHEAD\n', stderr: '' }
         }
 
-        if (command === 'git describe --tags --exact-match') {
+        if (args[0] === 'describe' && args.includes('--exact-match')) {
           throw new Error('fatal: no tag exactly matches')
         }
 
-        if (command === 'git rev-parse --abbrev-ref HEAD') {
+        if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') {
           return { stdout: 'develop\n', stderr: '' }
         }
 
-        if (command.startsWith('git clone ')) {
+        if (args[0] === 'clone') {
           await mkdir(join(repoPath, '.git', 'info'), { recursive: true })
         }
 
@@ -243,49 +244,43 @@ language = "english"
         versionStrategy: 'default'
       }, testDir)
 
-      expect(commands.some(command => command.startsWith('git clone '))).toBe(true)
-      expect(commands).toContain('git checkout HEAD')
-      expect(commands).not.toContain('git fetch --tags')
+      expect(execFileCommands.some(command => command.startsWith('git clone '))).toBe(true)
+      expect(execFileCommands).toContain('git checkout HEAD')
+      expect(execFileCommands.some(command => command.startsWith('git fetch --tags'))).toBe(false)
     })
 
     it('동일한 참조명이면서 커밋도 동일하면 업데이트를 건너뛰어야 함', async () => {
-      const commands: string[] = []
       const execFileCommands: string[] = []
       const repoPath = join(testDir, 'ck3/TestMod/upstream')
       await mkdir(join(repoPath, '.git'), { recursive: true })
 
-      execAsyncHandler = async (command: string) => {
-        commands.push(command)
+      execFileAsyncHandler = async (_file: string, args: readonly string[] = []) => {
+        const cmd = [_file, ...args].join(' ')
+        execFileCommands.push(cmd)
 
-        if (command === 'git status --porcelain') {
+        if (args[0] === 'status' && args[1] === '--porcelain') {
           return { stdout: '', stderr: '' }
         }
 
-        if (command.startsWith('git ls-remote --tags --refs')) {
+        if (args[0] === 'ls-remote' && args[1] === '--tags') {
           return { stdout: 'tagobjhash\trefs/tags/v1.0.0\n', stderr: '' }
         }
 
-        if (command === 'git describe --tags --exact-match') {
+        if (args[0] === 'ls-remote') {
+          return { stdout: 'commit123\trefs/tags/v1.0.0^{}\ntagobjhash\trefs/tags/v1.0.0\n', stderr: '' }
+        }
+
+        if (args[0] === 'describe' && args.includes('--exact-match')) {
           return { stdout: 'v1.0.0\n', stderr: '' }
         }
 
-        if (command === 'git rev-parse HEAD') {
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') {
           return { stdout: 'commit123\n', stderr: '' }
         }
 
         return { stdout: '', stderr: '' }
       }
 
-      execFileAsyncHandler = async (_file: string, args: readonly string[] = []) => {
-        execFileCommands.push([_file, ...args].join(' '))
-
-        if (args[0] === 'ls-remote') {
-          return { stdout: 'commit123\trefs/tags/v1.0.0^{}\ntagobjhash\trefs/tags/v1.0.0\n', stderr: '' }
-        }
-
-        return { stdout: '', stderr: '' }
-      }
-
       const { updateUpstreamOptimized } = await import('./upstream')
       await updateUpstreamOptimized({
         url: 'https://github.com/test/repo.git',
@@ -295,53 +290,39 @@ language = "english"
       }, testDir)
 
       expect(execFileCommands.some(command => command.includes('refs/tags/v1.0.0^{}'))).toBe(true)
-      expect(commands.some(command => command.startsWith('git fetch'))).toBe(false)
-      expect(commands.some(command => command.startsWith('git checkout'))).toBe(false)
+      expect(execFileCommands.some(command => command.startsWith('git fetch'))).toBe(false)
+      expect(execFileCommands.some(command => command.startsWith('git checkout'))).toBe(false)
     })
 
     it('동일한 참조명이어도 커밋이 다르면 업데이트를 진행해야 함', async () => {
-      const commands: string[] = []
       const execFileCommands: string[] = []
       const repoPath = join(testDir, 'ck3/TestMod/upstream')
       await mkdir(join(repoPath, '.git'), { recursive: true })
 
-      execAsyncHandler = async (command: string) => {
-        commands.push(command)
+      execFileAsyncHandler = async (_file: string, args: readonly string[] = []) => {
+        const cmd = [_file, ...args].join(' ')
+        execFileCommands.push(cmd)
 
-        if (command === 'git status --porcelain') {
+        if (args[0] === 'status' && args[1] === '--porcelain') {
           return { stdout: '', stderr: '' }
         }
 
-        if (command.startsWith('git ls-remote --tags --refs')) {
+        if (args[0] === 'ls-remote' && args[1] === '--tags') {
           return { stdout: 'newtaghash\trefs/tags/v1.0.0\n', stderr: '' }
         }
-
-        if (command === 'git describe --tags --exact-match') {
-          return { stdout: 'v1.0.0\n', stderr: '' }
-        }
-
-        if (command === 'git rev-parse HEAD') {
-          return { stdout: 'oldcommit\n', stderr: '' }
-        }
-
-        if (command === 'git fetch --tags') {
-          return { stdout: '', stderr: '' }
-        }
-
-        if (command.startsWith('git checkout')) {
-          return { stdout: '', stderr: '' }
-        }
-
-        return { stdout: '', stderr: '' }
-      }
-
-      execFileAsyncHandler = async (_file: string, args: readonly string[] = []) => {
-        execFileCommands.push([_file, ...args].join(' '))
 
         if (args[0] === 'ls-remote') {
           return { stdout: 'newcommit\trefs/tags/v1.0.0^{}\ntagobjhash\trefs/tags/v1.0.0\n', stderr: '' }
         }
 
+        if (args[0] === 'describe' && args.includes('--exact-match')) {
+          return { stdout: 'v1.0.0\n', stderr: '' }
+        }
+
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') {
+          return { stdout: 'oldcommit\n', stderr: '' }
+        }
+
         return { stdout: '', stderr: '' }
       }
 
@@ -354,26 +335,32 @@ language = "english"
       }, testDir)
 
       expect(execFileCommands.some(command => command.includes('refs/tags/v1.0.0^{}'))).toBe(true)
-      expect(commands).toContain('git fetch --tags')
-      expect(commands.some(command => command.startsWith('git checkout "v1.0.0"'))).toBe(true)
+      expect(execFileCommands).toContain('git fetch --tags')
+      expect(execFileCommands.some(command => command === 'git checkout v1.0.0')).toBe(true)
     })
   })
 
   describe('태그 clone/fetch 폴백', () => {
     it('태그 clone 실패 시 실패한 디렉토리를 정리한 뒤 기본 브랜치 clone으로 폴백해야 함', async () => {
-      const commands: string[] = []
+      const execFileCommands: string[] = []
       const repoPath = join(testDir, 'ck3/TestMod/upstream')
-      execAsyncHandler = async (command: string) => {
-        commands.push(command)
-        if (command.startsWith('git ls-remote --tags --refs')) {
+      execFileAsyncHandler = async (_file: string, args: readonly string[] = []) => {
+        const cmd = [_file, ...args].join(' ')
+        execFileCommands.push(cmd)
+
+        if (args[0] === 'ls-remote' && args[1] === '--tags') {
           return { stdout: 'abc123\trefs/tags/v1.0.0\n', stderr: '' }
         }
 
-        if (command.includes('git clone') && command.includes('--branch "v1.0.0"')) {
+        if (args[0] === 'ls-remote' && args[1] === '--symref') {
+          return { stdout: 'ref: refs/heads/main\tHEAD\n', stderr: '' }
+        }
+
+        if (args[0] === 'clone' && args.includes('--branch') && args.includes('v1.0.0')) {
           throw new Error('Remote branch v1.0.0 not found in upstream origin')
         }
 
-        if (command.startsWith('git clone ')) {
+        if (args[0] === 'clone') {
           await mkdir(join(repoPath, '.git', 'info'), { recursive: true })
         }
 
@@ -389,34 +376,41 @@ language = "english"
         versionStrategy: 'natural'
       }, testDir)
 
-      const tagCloneIndex = commands.findIndex(command => command.includes('git clone') && command.includes('--branch "v1.0.0"'))
-      const fallbackCloneIndex = commands.findIndex(command => command === `git clone --filter=blob:none --depth=1 --no-checkout "https://github.com/test/repo.git" "${repoPath}"`)
+      const tagCloneIndex = execFileCommands.findIndex(command => command.includes('git clone') && command.includes('--branch v1.0.0'))
+      const fallbackCloneIndex = execFileCommands.findIndex(command => command === `git clone --filter=blob:none --depth=1 --no-checkout https://github.com/test/repo.git ${repoPath}`)
 
       expect(tagCloneIndex).toBeGreaterThanOrEqual(0)
       expect(fallbackCloneIndex).toBeGreaterThan(tagCloneIndex)
     })
 
     it('shallow 저장소에서 태그 fetch가 ref-not-found면 기본 브랜치 fetch로 폴백해야 함', async () => {
-      const commands: string[] = []
-      execAsyncHandler = async (command: string) => {
-        commands.push(command)
-        if (command === 'git status --porcelain') {
+      const execFileCommands: string[] = []
+      execFileAsyncHandler = async (_file: string, args: readonly string[] = []) => {
+        const cmd = [_file, ...args].join(' ')
+        execFileCommands.push(cmd)
+
+        if (args[0] === 'status' && args[1] === '--porcelain') {
           return { stdout: '', stderr: '' }
         }
-        if (command.startsWith('git ls-remote --tags --refs')) {
+
+        if (args[0] === 'ls-remote' && args[1] === '--tags') {
           return { stdout: 'abc123\trefs/tags/v2.0.0\n', stderr: '' }
         }
-        if (command === 'git describe --tags --exact-match') {
+
+        if (args[0] === 'ls-remote' && args[1] === '--symref') {
+          return { stdout: 'ref: refs/heads/main\tHEAD\n', stderr: '' }
+        }
+
+        if (args[0] === 'describe' && args.includes('--exact-match')) {
           throw new Error('fatal: no tag exactly matches')
         }
-        if (command === 'git rev-parse --abbrev-ref HEAD') {
+
+        if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') {
           return { stdout: 'main\n', stderr: '' }
         }
-        if (command === 'git fetch --depth=1 origin tag "v2.0.0"') {
+
+        if (args[0] === 'fetch' && args.includes('tag') && args.includes('v2.0.0')) {
           throw new Error('Remote branch v2.0.0 not found in upstream origin')
-        }
-        if (command.startsWith('git ls-remote --symref')) {
-          return { stdout: 'ref: refs/heads/main\tHEAD\n', stderr: '' }
         }
 
         return { stdout: '', stderr: '' }
@@ -434,10 +428,10 @@ language = "english"
         versionStrategy: 'natural'
       }, testDir)
 
-      expect(commands).toContain('git fetch --depth=1 origin tag "v2.0.0"')
-      expect(commands).toContain('git fetch --depth=1 origin "main"')
-      expect(commands).toContain('git checkout "main"')
-      expect(commands).toContain('git reset --hard "origin/main"')
+      expect(execFileCommands).toContain('git fetch --depth=1 origin tag v2.0.0')
+      expect(execFileCommands).toContain('git fetch --depth=1 origin main')
+      expect(execFileCommands).toContain('git checkout main')
+      expect(execFileCommands).toContain('git reset --hard origin/main')
     })
   })
 

--- a/scripts/utils/upstream.test.ts
+++ b/scripts/utils/upstream.test.ts
@@ -206,8 +206,7 @@ language = "english"
       await mkdir(join(repoPath, '.git'), { recursive: true })
 
       execFileAsyncHandler = async (_file: string, args: readonly string[] = []) => {
-        const cmd = [_file, ...args].join(' ')
-        execFileCommands.push(cmd)
+        execFileCommands.push([_file, ...args].join(' '))
 
         if (args[0] === 'status' && args[1] === '--porcelain') {
           return { stdout: ' M localization/english/test.yml\n', stderr: '' }
@@ -255,8 +254,7 @@ language = "english"
       await mkdir(join(repoPath, '.git'), { recursive: true })
 
       execFileAsyncHandler = async (_file: string, args: readonly string[] = []) => {
-        const cmd = [_file, ...args].join(' ')
-        execFileCommands.push(cmd)
+        execFileCommands.push([_file, ...args].join(' '))
 
         if (args[0] === 'status' && args[1] === '--porcelain') {
           return { stdout: '', stderr: '' }
@@ -300,8 +298,7 @@ language = "english"
       await mkdir(join(repoPath, '.git'), { recursive: true })
 
       execFileAsyncHandler = async (_file: string, args: readonly string[] = []) => {
-        const cmd = [_file, ...args].join(' ')
-        execFileCommands.push(cmd)
+        execFileCommands.push([_file, ...args].join(' '))
 
         if (args[0] === 'status' && args[1] === '--porcelain') {
           return { stdout: '', stderr: '' }
@@ -345,8 +342,7 @@ language = "english"
       const execFileCommands: string[] = []
       const repoPath = join(testDir, 'ck3/TestMod/upstream')
       execFileAsyncHandler = async (_file: string, args: readonly string[] = []) => {
-        const cmd = [_file, ...args].join(' ')
-        execFileCommands.push(cmd)
+        execFileCommands.push([_file, ...args].join(' '))
 
         if (args[0] === 'ls-remote' && args[1] === '--tags') {
           return { stdout: 'abc123\trefs/tags/v1.0.0\n', stderr: '' }
@@ -386,8 +382,7 @@ language = "english"
     it('shallow 저장소에서 태그 fetch가 ref-not-found면 기본 브랜치 fetch로 폴백해야 함', async () => {
       const execFileCommands: string[] = []
       execFileAsyncHandler = async (_file: string, args: readonly string[] = []) => {
-        const cmd = [_file, ...args].join(' ')
-        execFileCommands.push(cmd)
+        execFileCommands.push([_file, ...args].join(' '))
 
         if (args[0] === 'status' && args[1] === '--porcelain') {
           return { stdout: '', stderr: '' }

--- a/scripts/utils/upstream.ts
+++ b/scripts/utils/upstream.ts
@@ -7,7 +7,7 @@
  * meta.toml 파일에서 모든 설정 정보 (URL, localization 경로)를 읽어옵니다.
  */
 
-import { exec, execFile } from 'node:child_process'
+import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import { access, mkdir, readFile, writeFile, readdir, rm } from 'node:fs/promises'
 import { join, dirname } from 'pathe'
@@ -18,7 +18,6 @@ import { delay } from './delay'
 import { parseToml } from '../parser/toml'
 import { reportVersionStrategyError } from './version-strategy-reporter'
 
-const execAsync = promisify(exec)
 const execFileAsync = promisify(execFile)
 
 export type VersionStrategy = 'semantic' | 'natural' | 'default' | 'github'
@@ -424,7 +423,7 @@ async function getSemanticVersion(repoUrl: string, configPath: string): Promise<
 async function getNaturalVersion(repoUrl: string, configPath: string): Promise<{ type: 'tag', name: string }> {
   return await upstreamRetry(
     async () => {
-      const { stdout: tagsOutput } = await execAsync(`git ls-remote --tags --refs "${repoUrl}"`, {
+      const { stdout: tagsOutput } = await execFileAsync('git', ['ls-remote', '--tags', '--refs', repoUrl], {
         timeout: 30000
       })
       
@@ -466,7 +465,7 @@ async function getNaturalVersion(repoUrl: string, configPath: string): Promise<{
 async function getDefaultBranch(repoUrl: string, configPath: string): Promise<{ type: 'branch', name: string }> {
   return await upstreamRetry(
     async () => {
-      const { stdout: headOutput } = await execAsync(`git ls-remote --symref "${repoUrl}" HEAD`, {
+      const { stdout: headOutput } = await execFileAsync('git', ['ls-remote', '--symref', repoUrl, 'HEAD'], {
         timeout: 10000
       })
       
@@ -543,7 +542,7 @@ async function cloneOptimizedRepository(targetPath: string, config: UpstreamConf
     
     // 3. Sparse checkout 설정
     log.start(`[${config.path}] Sparse checkout 설정 중...`)
-    await execAsync('git sparse-checkout init', { cwd: targetPath })
+    await execFileAsync('git', ['sparse-checkout', 'init'], { cwd: targetPath })
     
     // 4. Localization 경로만 설정 (파일에 직접 작성)
     const sparseCheckoutPath = join(targetPath, '.git', 'info', 'sparse-checkout')
@@ -572,13 +571,13 @@ async function cloneWithFallback(
   latestRef: { type: 'tag' | 'branch', name: string }
 ): Promise<void> {
   if (latestRef.type === 'branch') {
-    await execAsync(`git clone --filter=blob:none --depth=1 --single-branch --branch "${latestRef.name}" --no-checkout "${config.url}" "${targetPath}"`)
+    await execFileAsync('git', ['clone', '--filter=blob:none', '--depth=1', '--single-branch', '--branch', latestRef.name, '--no-checkout', config.url, targetPath])
     return
   }
 
   try {
     // 태그가 있는 경우, 해당 태그를 기준으로 shallow clone
-    await execAsync(`git clone --filter=blob:none --depth=1 --branch "${latestRef.name}" --no-checkout "${config.url}" "${targetPath}"`)
+    await execFileAsync('git', ['clone', '--filter=blob:none', '--depth=1', '--branch', latestRef.name, '--no-checkout', config.url, targetPath])
   } catch (error) {
     if (!isRemoteRefNotFoundError(error)) {
       throw error
@@ -586,7 +585,7 @@ async function cloneWithFallback(
 
     log.warn(`[${config.path}] 태그(${latestRef.name})를 찾을 수 없어 기본 브랜치로 폴백합니다`)
     await rm(targetPath, { recursive: true, force: true })
-    await execAsync(`git clone --filter=blob:none --depth=1 --no-checkout "${config.url}" "${targetPath}"`)
+    await execFileAsync('git', ['clone', '--filter=blob:none', '--depth=1', '--no-checkout', config.url, targetPath])
   }
 }
 
@@ -621,7 +620,7 @@ export async function isShallowRepository(repositoryPath: string): Promise<boole
 async function updateExistingRepository(repositoryPath: string, config: UpstreamConfig): Promise<void> {
   try {
     // Git 상태 확인
-    const { stdout: status } = await execAsync('git status --porcelain', { cwd: repositoryPath })
+    const { stdout: status } = await execFileAsync('git', ['status', '--porcelain'], { cwd: repositoryPath })
     
     if (status.trim()) {
       log.warn(`[${config.path}] 로컬 변경사항이 있어 upstream 저장소를 재클론합니다`)
@@ -643,12 +642,12 @@ async function updateExistingRepository(repositoryPath: string, config: Upstream
     let currentType: 'tag' | 'branch'
     try {
       // 먼저 태그인지 확인
-      const { stdout } = await execAsync('git describe --tags --exact-match', { cwd: repositoryPath })
+      const { stdout } = await execFileAsync('git', ['describe', '--tags', '--exact-match'], { cwd: repositoryPath })
       current = stdout.trim()
       currentType = 'tag'
     } catch {
       // 태그가 아니면 브랜치 이름 가져오기
-      const { stdout } = await execAsync('git rev-parse --abbrev-ref HEAD', { cwd: repositoryPath })
+      const { stdout } = await execFileAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: repositoryPath })
       current = stdout.trim()
       currentType = 'branch'
     }
@@ -657,7 +656,7 @@ async function updateExistingRepository(repositoryPath: string, config: Upstream
       const remoteCommitHash = await getRemoteRefCommitHash(config.url, latestRef)
 
       if (remoteCommitHash) {
-        const { stdout: localCommitHashOutput } = await execAsync('git rev-parse HEAD', { cwd: repositoryPath })
+        const { stdout: localCommitHashOutput } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repositoryPath })
         const localCommitHash = localCommitHashOutput.trim()
 
         if (localCommitHash === remoteCommitHash) {
@@ -687,16 +686,16 @@ async function updateExistingRepository(repositoryPath: string, config: Upstream
           // 태그가 사라진 경우 기본 브랜치로 폴백하여 이후 업데이트도 안정적으로 유지
           const defaultBranchRef = await getDefaultBranch(config.url, config.path)
           log.warn(`[${config.path}] 태그(${latestRef.name}) fetch 실패로 기본 브랜치(${defaultBranchRef.name})로 폴백합니다`)
-          await execAsync(`git fetch --depth=1 origin "${defaultBranchRef.name}"`, { cwd: repositoryPath })
+          await execFileAsync('git', ['fetch', '--depth=1', 'origin', defaultBranchRef.name], { cwd: repositoryPath })
           updateRef = defaultBranchRef
         }
       } else {
         // 브랜치의 경우 기존 방식대로
-        await execAsync(`git fetch --depth=1 origin "${latestRef.name}"`, { cwd: repositoryPath })
+        await execFileAsync('git', ['fetch', '--depth=1', 'origin', latestRef.name], { cwd: repositoryPath })
       }
     } else {
       // 일반 clone의 경우 모든 변경사항 가져오기
-      await execAsync('git fetch --tags', { cwd: repositoryPath })
+      await execFileAsync('git', ['fetch', '--tags'], { cwd: repositoryPath })
     }
     
     // 최신 버전으로 체크아웃
@@ -729,7 +728,7 @@ export async function checkoutLatestVersionForShallowClone(repositoryPath: strin
     // 현재 브랜치(HEAD)를 체크아웃하면 됩니다
     // git sparse-checkout reapply는 --no-checkout 이후 파일을 체크아웃하지 않으므로
     // git checkout HEAD를 사용하여 sparse-checkout 패턴에 맞는 파일을 실제로 체크아웃합니다
-    await execAsync('git checkout HEAD', { cwd: repositoryPath })
+    await execFileAsync('git', ['checkout', 'HEAD'], { cwd: repositoryPath })
     log.info(`[${configPath}] 최신 버전 체크아웃 완료`)
   } catch (error) {
     log.error(`[${configPath}] 체크아웃 실패:`, error)

--- a/scripts/utils/upstream.ts
+++ b/scripts/utils/upstream.ts
@@ -678,7 +678,7 @@ async function updateExistingRepository(repositoryPath: string, config: Upstream
       if (latestRef.type === 'tag') {
         // shallow clone에서 특정 태그로 업데이트하려면 해당 태그를 fetch
         try {
-          await execAsync(`git fetch --depth=1 origin tag "${latestRef.name}"`, { cwd: repositoryPath })
+          await execFileAsync('git', ['fetch', '--depth=1', 'origin', 'tag', latestRef.name], { cwd: repositoryPath })
         } catch (error) {
           if (!isRemoteRefNotFoundError(error)) {
             throw error
@@ -701,13 +701,13 @@ async function updateExistingRepository(repositoryPath: string, config: Upstream
     
     // 최신 버전으로 체크아웃
     log.start(`[${config.path}] ${updateRef.type} ${updateRef.name}(으)로 업데이트 중...`)
-    await execAsync(`git checkout "${updateRef.name}"`, { cwd: repositoryPath })
+    await execFileAsync('git', ['checkout', updateRef.name], { cwd: repositoryPath })
     
     if (updateRef.type === 'branch') {
       // 브랜치의 경우 원격 상태로 강제 리셋 (브랜치는 변경 가능하므로)
       // 태그는 불변이므로 checkout만으로 충분함
       // upstream 리포지토리는 읽기 전용이므로 로컬 변경사항은 무시하고 원격 상태로 리셋
-      await execAsync(`git reset --hard "origin/${updateRef.name}"`, { cwd: repositoryPath })
+      await execFileAsync('git', ['reset', '--hard', `origin/${updateRef.name}`], { cwd: repositoryPath })
     }
     
     log.success(`[${config.path}] 업데이트 완료 (${updateRef.type}: ${updateRef.name})`)


### PR DESCRIPTION
Potential fix for [https://github.com/dungsil-ai/pat/security/code-scanning/11](https://github.com/dungsil-ai/pat/security/code-scanning/11)

일반적인 해결 방법은 **셸을 거치지 않는 실행 방식**으로 바꾸는 것입니다. 즉, `exec`/`execAsync`에 문자열 명령을 넘기지 말고, `execFile`/`execFileAsync`에 실행 파일과 인자 배열을 분리해서 전달해야 합니다. 이렇게 하면 ref 이름이 악성 문자열이어도 셸 메타문자로 해석되지 않습니다.

이 파일에서는 이미 `execFile`과 `execFileAsync`가 준비되어 있으므로, `scripts/utils/upstream.ts` 내 문제 구간(특히 681, 704, 710 라인 인근)의 Git 명령을 다음처럼 치환하는 것이 최선입니다.

- `git fetch --depth=1 origin tag "${latestRef.name}"` → `execFileAsync('git', ['fetch', '--depth=1', 'origin', 'tag', latestRef.name], { cwd })`
- `git checkout "${updateRef.name}"` → `execFileAsync('git', ['checkout', updateRef.name], { cwd })`
- `git reset --hard "origin/${updateRef.name}"` → `execFileAsync('git', ['reset', '--hard', `origin/${updateRef.name}`], { cwd })`

기능 변화 없이 보안성만 개선됩니다. 추가 import/의존성은 필요 없습니다.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
