### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete multi-character sanitization

### DIFF
--- a/scripts/utils/translate.ts
+++ b/scripts/utils/translate.ts
@@ -120,6 +120,8 @@ function isVariableOnlyText(text: string): boolean {
 
   // 5. 앵글 브래킷 변수 제거: <...>
   remaining = remaining.replace(/<[a-zA-Z0-9_\-.]+>/g, '')
+  // 겹침/재조합 입력으로 남을 수 있는 앵글 브래킷 문자까지 제거
+  remaining = remaining.replace(/[<>]/g, '')
 
   // 6. 해시 포맷 마커 제거: #...# 또는 #...#!
   remaining = remaining.replace(/#[a-zA-Z_]+#!?/g, '')


### PR DESCRIPTION
Potential fix for [https://github.com/dungsil-ai/pat/security/code-scanning/5](https://github.com/dungsil-ai/pat/security/code-scanning/5)

일반적으로는 다문자 패턴(예: `<...>`)을 한 번에 지우기보다, 위험한 구분 문자 자체(`<`, `>`)를 제거하거나, 고정점(fixed-point)까지 반복 치환해야 합니다.

이 코드에서 기능 변경을 최소화하는 최선의 방법은 **5번 단계(앵글 브래킷 변수 제거)에서 `<...>` 패턴 제거 후, 남아있는 `<`와 `>`를 추가로 제거**하는 것입니다. 이렇게 하면 기존에 의도한 `<token>` 제거는 유지하면서, 겹침/재조합으로 남는 `<script` 잔여 문자열 가능성도 차단할 수 있습니다.

수정 위치:
- 파일: `scripts/utils/translate.ts`
- 함수: `isVariableOnlyText`
- 변경 라인 영역: 현재 `remaining = remaining.replace(/<[a-zA-Z0-9_\-.]+>/g, '')`가 있는 5번 단계

필요 사항:
- 새 import 불필요
- 새 메서드 정의 불필요
- 기존 코드 블록 내 치환 라인 1개를 2단계 치환으로 교체


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
